### PR TITLE
Transition final polish

### DIFF
--- a/Source/Core/Extensions/UIViewController+StatusBar.swift
+++ b/Source/Core/Extensions/UIViewController+StatusBar.swift
@@ -1,0 +1,31 @@
+//
+//  UIViewController+StatusBar.swift
+//  Pods
+//
+//  Created by Juan sebastian Sanzone on 12/13/19.
+//
+
+import UIKit
+
+internal extension UIViewController {
+    func getStatusBarHeight() -> CGFloat {
+        var topDeltaMargin: CGFloat = 20
+        if #available(iOS 11.0, *) {
+            let window = UIApplication.shared.keyWindow
+            let topSafeAreaInset = window?.safeAreaInsets.top
+            if let topDeltaInset = topSafeAreaInset, topDeltaInset > 0 {
+                topDeltaMargin = topDeltaInset
+            }
+        }
+        return topDeltaMargin
+    }
+
+    func addStatusBarBackground(color: UIColor?) {
+        let statusView = UIView(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: getStatusBarHeight()))
+        statusView.translatesAutoresizingMaskIntoConstraints = true
+        statusView.backgroundColor = color
+        view.addSubview(statusView)
+    }
+}
+
+

--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -21,6 +21,7 @@ open class MLCardFormBuilder: NSObject {
     internal var trackingConfiguration: MLCardFormTrackerConfiguration?
     internal var navigationCustomBackgroundColor: UIColor?
     internal var navigationCustomTextColor: UIColor?
+    internal var animateOnLoad: Bool = false
     
     // MARK: Initialization
     
@@ -88,6 +89,16 @@ extension MLCardFormBuilder {
     open func setNavigationBarCustomColor(backgroundColor: UIColor, textColor: UIColor) -> MLCardFormBuilder {
         self.navigationCustomBackgroundColor = backgroundColor
         self.navigationCustomTextColor = textColor
+        return self
+    }
+
+    /**
+     Determinates if MLCardForm ViewController should be present animated or not. Default is no animated. Use true only for your own custom transitions.
+     - parameter animated: `Bool`
+     */
+    @discardableResult
+    open func setAnimated(_ animated: Bool) -> MLCardFormBuilder {
+        self.animateOnLoad = animated
         return self
     }
 }

--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -19,6 +19,8 @@ open class MLCardFormBuilder: NSObject {
     internal var flowId: String?
     internal var excludedPaymentTypes: [String]?
     internal var trackingConfiguration: MLCardFormTrackerConfiguration?
+    internal var navigationCustomBackgroundColor: UIColor?
+    internal var navigationCustomTextColor: UIColor?
     
     // MARK: Initialization
     
@@ -74,6 +76,18 @@ extension MLCardFormBuilder {
     @discardableResult @objc(setTrackingConfigurationWithConfiguration:)
     open func setTrackingConfiguration(_ trackingConfiguration: MLCardFormTrackerConfiguration) -> MLCardFormBuilder {
         self.trackingConfiguration = trackingConfiguration
+        return self
+    }
+
+    /**
+     Customize navigation bar background color and tint text color.
+     - parameter backgroundColor: `UIColor` object.
+     - parameter textColor: `UIColor` object.
+     */
+    @discardableResult
+    open func setNavigationBarCustomColor(backgroundColor: UIColor, textColor: UIColor) -> MLCardFormBuilder {
+        self.navigationCustomBackgroundColor = backgroundColor
+        self.navigationCustomTextColor = textColor
         return self
     }
 }

--- a/Source/UI/Controllers/MLCardFormBaseViewController.swift
+++ b/Source/UI/Controllers/MLCardFormBaseViewController.swift
@@ -16,28 +16,18 @@ open class MLCardFormBaseViewController: UIViewController {
     var navBarTextColor = MLStyleSheetManager.styleSheet.blackColor
     var navBarBackgroundColor = MLStyleSheetManager.styleSheet.primaryColor
 
-    override open var preferredStatusBarStyle : UIStatusBarStyle {
-        return .lightContent
-    }
-
-    open override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.loadStyles()
-    }
-
-    private func loadStyles() {
+    internal func loadStyles(customNavigationBackgroundColor: UIColor? = nil, customNavigationTextColor: UIColor? = nil) {
         if let navigationController = navigationController {
             // Navigation bar colors
             let fontSize: CGFloat = 18
             let font = getFontWithSize(font: fontName, size: fontSize)
-            let titleTextAttributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key.foregroundColor: navBarTextColor, NSAttributedString.Key.font: font]
+            let titleTextAttributes: [NSAttributedString.Key: Any] = [NSAttributedString.Key.foregroundColor: customNavigationTextColor ?? navBarTextColor, NSAttributedString.Key.font: font]
             navigationController.navigationBar.titleTextAttributes = titleTextAttributes
-            navigationController.navigationBar.tintColor = navBarBackgroundColor
-            navigationController.navigationBar.barTintColor = navBarBackgroundColor
-//            navigationController.navigationBar.isTranslucent = false
-            navigationController.view.backgroundColor = navBarBackgroundColor
-            // Navigation back button
-            setupBackButton()
+            navigationController.navigationBar.tintColor = customNavigationBackgroundColor ?? navBarBackgroundColor
+            navigationController.navigationBar.barTintColor = customNavigationBackgroundColor ?? navBarBackgroundColor
+            // navigationController.navigationBar.isTranslucent = false
+            navigationController.navigationBar.backgroundColor = customNavigationBackgroundColor ?? navBarBackgroundColor
+            setupBackButton(textColor: customNavigationTextColor ?? navBarTextColor)
         }
     }
 
@@ -49,13 +39,13 @@ open class MLCardFormBaseViewController: UIViewController {
         return UIInterfaceOrientationMask.portrait
     }
 
-    private func setupBackButton() {
+    private func setupBackButton(textColor: UIColor? = nil) {
         let backButton = UIBarButtonItem()
         let back = UIImage(named: "back", in: Bundle(for: type(of: self)), compatibleWith: nil)
         backButton.image = back
         backButton.style = .plain
         backButton.target = self
-        backButton.tintColor = navBarTextColor
+        backButton.tintColor = textColor
         backButton.action = #selector(pop)
         navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = backButton

--- a/Source/UI/Controllers/MLCardFormBaseViewController.swift
+++ b/Source/UI/Controllers/MLCardFormBaseViewController.swift
@@ -25,7 +25,6 @@ open class MLCardFormBaseViewController: UIViewController {
             navigationController.navigationBar.titleTextAttributes = titleTextAttributes
             navigationController.navigationBar.tintColor = customNavigationBackgroundColor ?? navBarBackgroundColor
             navigationController.navigationBar.barTintColor = customNavigationBackgroundColor ?? navBarBackgroundColor
-            // navigationController.navigationBar.isTranslucent = false
             navigationController.navigationBar.backgroundColor = customNavigationBackgroundColor ?? navBarBackgroundColor
             setupBackButton(textColor: customNavigationTextColor ?? navBarTextColor)
         }

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -40,12 +40,19 @@ open class MLCardFormViewController: MLCardFormBaseViewController {
             setupCardDrawer()
             setupFieldCollectionView()
             showViewWithAnimation()
-            title = AppBar.Generic.title
             setupTempTextField()
             setupSpinner()
             viewModel.viewModelDelegate = self
             setupControllerCompleted = true
         }
+    }
+
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        title = AppBar.Generic.title
+        let (backgroundNavigationColor, textNavigationColor) = viewModel.getNavigationBarCustomColor()
+        super.loadStyles(customNavigationBackgroundColor: backgroundNavigationColor, customNavigationTextColor: textNavigationColor)
+        addStatusBarBackground(color: backgroundNavigationColor)
     }
 
     override open func viewWillAppear(_ animated: Bool) {
@@ -190,16 +197,17 @@ private extension MLCardFormViewController {
     }
 
     private func showViewWithAnimation() {
-        UIView.animate(withDuration: 0.5) { [weak self] in
-            self?.cardFieldCollectionView?.alpha = 1
-            self?.cardContainerView.alpha = 1
-        }
         if let field = viewModel.cardFormFields?.first?.first {
             field.doFocus()
             if viewModel.updateProgressWithCompletion {
                 updateProgressFromField(field)
             }
         }
+
+        UIView.animate(withDuration: 0.3, animations: { [weak self] in
+            self?.cardFieldCollectionView?.alpha = 1
+            self?.cardContainerView.alpha = 1
+        })
     }
 
     private func updateProgressFromField(_ cardFormField: MLCardFormField) {

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -53,6 +53,7 @@ open class MLCardFormViewController: MLCardFormBaseViewController {
         let (backgroundNavigationColor, textNavigationColor) = viewModel.getNavigationBarCustomColor()
         super.loadStyles(customNavigationBackgroundColor: backgroundNavigationColor, customNavigationTextColor: textNavigationColor)
         addStatusBarBackground(color: backgroundNavigationColor)
+        setupCardContainer()
     }
 
     override open func viewWillAppear(_ animated: Bool) {
@@ -151,8 +152,14 @@ private extension MLCardFormViewController {
     
     func setupCardDrawer() {
         cardDrawer = MLCardDrawerController(viewModel.cardUIHandler, viewModel.cardDataHandler)
-        cardDrawer?.setUp(inView: cardContainerView).show()
+        cardDrawer?.view.backgroundColor = .clear
+        cardDrawer?.setUp(inView: cardContainerView)
         cardContainerView.addShadow()
+    }
+
+    func setupCardContainer() {
+        cardContainerView.backgroundColor = .clear
+        containerBottomConstraint.constant = containerBottomConstraint.constant - UIScreen.main.bounds.height
     }
     
     func setupFieldCollectionView() {

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -19,17 +19,16 @@ open class MLCardFormViewController: MLCardFormBaseViewController {
     // Constraints.
     @IBOutlet weak var containerBottomConstraint: NSLayoutConstraint!
 
-    // MARK: Private Vars
-    private weak var lifeCycleDelegate: MLCardFormLifeCycleDelegate?
-    private var cardDrawer: MLCardDrawerController?
-    private weak var cardFieldCollectionView: UICollectionView?
-    
+    // MARK: Constants
     private let cardFieldCellInset: CGFloat = 30
     private let cardFieldHeight: CGFloat = 75
+    internal let viewModel: MLCardFormViewModel = MLCardFormViewModel()
 
-    // MARK: IssuersScreen vars
+    // MARK: Private Vars
+    private weak var lifeCycleDelegate: MLCardFormLifeCycleDelegate?
+    private weak var cardFieldCollectionView: UICollectionView?
+    private var cardDrawer: MLCardDrawerController?
     private var issuersVC: MLCardFormIssuersViewController?
-    let viewModel: MLCardFormViewModel = MLCardFormViewModel()
 
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -159,7 +158,8 @@ private extension MLCardFormViewController {
                 cardView.topAnchor.constraint(equalTo: cardContainerView.topAnchor),
                 cardView.leadingAnchor.constraint(equalTo: cardContainerView.leadingAnchor),
                 cardView.bottomAnchor.constraint(equalTo: cardContainerView.bottomAnchor),
-                cardView.trailingAnchor.constraint(equalTo: cardContainerView.trailingAnchor)])
+                cardView.trailingAnchor.constraint(equalTo: cardContainerView.trailingAnchor)
+            ])
         }
     }
 
@@ -213,9 +213,6 @@ private extension MLCardFormViewController {
     func animateCardAppear() {
         if let field = viewModel.cardFormFields?.first?.first {
             field.doFocus()
-            if viewModel.updateProgressWithCompletion {
-                updateProgressFromField(field)
-            }
         }
         UIView.animate(withDuration: 0.5, animations: { [weak self] in
             self?.cardFieldCollectionView?.alpha = 1
@@ -223,11 +220,18 @@ private extension MLCardFormViewController {
     }
 
     func updateProgressFromField(_ cardFormField: MLCardFormField) {
+        let isFirstTime: Bool = progressBarView.progress == 0
         let animator = UIViewPropertyAnimator(duration: 0.6, dampingRatio: 0.9) { [weak self] in
             guard let self = self else { return }
             self.progressBarView.setProgress(self.viewModel.getProgressFromField(cardFormField), animated: true)
         }
-        animator.startAnimation()
+        if isFirstTime {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.60) {
+                animator.startAnimation()
+            }
+        } else {
+            animator.startAnimation()
+        }
     }
 
     func setupTempTextField() {

--- a/Source/ViewModel/CardDrawer/DefaultCardUIHandler.swift
+++ b/Source/ViewModel/CardDrawer/DefaultCardUIHandler.swift
@@ -14,9 +14,9 @@ class DefaultCardUIHandler: NSObject, CardUI {
     var placeholderExpiration = "MM/AA"
     var bankImage: UIImage?
     var cardPattern = [4, 4, 4, 4]
-    var cardFontColor: UIColor = UIColor(red: 102/255, green: 102/255, blue: 102/255, alpha: 1)
+    var cardFontColor: UIColor = .white
     var cardLogoImage: UIImage?
-    var cardBackgroundColor: UIColor = UIColor(red: 213/255, green: 213/255, blue: 213/255, alpha: 1)
+    var cardBackgroundColor: UIColor = .clear
     var securityCodeLocation: MLCardSecurityCodeLocation = .back
     var defaultUI = true
     var securityCodePattern = 3

--- a/Source/ViewModel/CardDrawer/DefaultCardUIHandler.swift
+++ b/Source/ViewModel/CardDrawer/DefaultCardUIHandler.swift
@@ -14,9 +14,9 @@ class DefaultCardUIHandler: NSObject, CardUI {
     var placeholderExpiration = "MM/AA"
     var bankImage: UIImage?
     var cardPattern = [4, 4, 4, 4]
-    var cardFontColor: UIColor = .white
+    var cardFontColor: UIColor = UIColor(red: 102/255, green: 102/255, blue: 102/255, alpha: 1)
     var cardLogoImage: UIImage?
-    var cardBackgroundColor: UIColor = .clear
+    var cardBackgroundColor: UIColor = UIColor(red: 213/255, green: 213/255, blue: 213/255, alpha: 1)
     var securityCodeLocation: MLCardSecurityCodeLocation = .back
     var defaultUI = true
     var securityCodePattern = 3

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -251,6 +251,10 @@ final class MLCardFormViewModel {
     func getNavigationBarCustomColor() -> (backgroundColor: UIColor?, textColor: UIColor?) {
         return (builder?.navigationCustomBackgroundColor, builder?.navigationCustomTextColor)
     }
+
+    func shouldAnimateOnLoad() -> Bool {
+        return builder?.animateOnLoad ?? false
+    }
 }
 
 // MARK: IssuersScreen

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -56,8 +56,11 @@ final class MLCardFormViewModel {
     private let addCardService: MLCardFormAddCardService = MLCardFormAddCardService()
 
     weak var viewModelDelegate: MLCardFormViewModelProtocol?
+
+    private var builder: MLCardFormBuilder?
     
     func updateWithBuilder(_ builder: MLCardFormBuilder) {
+        self.builder = builder
         trackingConfiguration = builder.trackingConfiguration
         addCardService.update(publicKey: builder.publicKey, privateKey: builder.privateKey)
         binService.update(siteId: builder.siteId, excludedPaymentTypes: builder.excludedPaymentTypes, flowId: builder.flowId)
@@ -243,6 +246,10 @@ final class MLCardFormViewModel {
             cardHandlerToUpdate.update(cardUI: cardUI)
             viewModelDelegate?.shouldUpdateCard(cardUI: cardUIHandler)
         }
+    }
+
+    func getNavigationBarCustomColor() -> (backgroundColor: UIColor?, textColor: UIColor?) {
+        return (builder?.navigationCustomBackgroundColor, builder?.navigationCustomTextColor)
     }
 }
 


### PR DESCRIPTION
- Se arregla el glitch que tenia CardDrawer al mostrarse.
- Se elimina el flag para saber si se llamo al viewDidApear y se mueve todo al viewDidLoad como debe ser.
- Se corrige la navBar para que pueda pintarse correctamente junto con su status bar.
- Se remueve el "status bar" tinit color harcoded. Ya que eso lo vamos a heredar del integrador. De la app del integrador. (Antes tenia un override)
- Se crea un nuevo modo de inicializacion. Por defecto es NO-Animado. Para otras integraciones, como puede ser Home, Mis tarjetas. Ahi La pantalla arranca ya con la tarjeta y los campos y lo unico que hace es mostrar el teclado cuando una vez que se hace el push (viewDidAppear)
- Se contempla en el builder el modo de animated. Es el que usamos en la integracion de PX. Donde ahi si la animacion comienza con un offset en la tarjeta y el teclado. 
- Se permite la customizacion de la navigation bar tint y background color.