### PR TITLE
Add card number validation if first request fails and card type is Am…

### DIFF
--- a/Source/Core/Extensions/String+Additions.swift
+++ b/Source/Core/Extensions/String+Additions.swift
@@ -13,4 +13,27 @@ internal extension String {
         guard let value = value else { return true }
         return value.isEmpty
     }
+    
+    /// Remove characters from given set from the string. Looks for characters
+    /// from set in the whole string, not only its beginning and end.
+    ///
+    /// - Parameter set: Character set, with characters we want to remove
+    /// - Returns: New String with characters from given set removed
+    func removingCharactersInSet(_ set: CharacterSet) -> String {
+        let stringParts = self.components(separatedBy: set)
+        let notEmptyStringParts = stringParts.filter { text in
+            text.isEmpty == false
+        }
+        let result = notEmptyStringParts.joined(separator: "")
+        return result
+    }
+    
+    
+    /// Remove whitespace and newlines characters from the string. Looks for
+    /// characters from set in the whole string, not only its beginning and end.
+    ///
+    /// - Returns: New String with whitespace and newline characters removed
+    func removingWhitespaceAndNewlines() -> String {
+        return self.removingCharactersInSet(CharacterSet.whitespacesAndNewlines)
+    }
 }

--- a/Source/Core/Extensions/UIColor+Additions.swift
+++ b/Source/Core/Extensions/UIColor+Additions.swift
@@ -1,0 +1,23 @@
+//
+//  UIColor+Additions.swift
+//  FXBlurView
+//
+//  Created by Eric Ertl on 20/12/2019.
+//
+
+import Foundation
+
+internal extension UIColor {
+    func toHexString() -> String {
+        var r:CGFloat = 0
+        var g:CGFloat = 0
+        var b:CGFloat = 0
+        var a:CGFloat = 0
+        
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        
+        let rgb:Int = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(b*255)<<0
+        
+        return String(format:"#%06x", rgb)
+    }
+}

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -462,7 +462,7 @@ extension MLCardFormViewController: IssuerSelectedProtocol {
 // MARK: MLCardFormViewModelProtocol
 extension MLCardFormViewController: MLCardFormViewModelProtocol {
     
-    func shouldUpdateFields(remoteSettings: [MLCardFormFieldSetting]) {
+    func shouldUpdateFields(remoteSettings: [MLCardFormFieldSetting]?) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.viewModel.tempTextField.doFocus()

--- a/Source/ViewModel/FieldProperty/CardNumberFormFieldProperty.swift
+++ b/Source/ViewModel/FieldProperty/CardNumberFormFieldProperty.swift
@@ -94,7 +94,7 @@ struct CardNumberFormFieldProperty : MLCardFormFieldPropertyProtocol {
         guard let value = value else { return false }
         let cleanValue = value.removingWhitespaceAndNewlines()
         
-        if let mask = remoteSetting?.mask, value.count == mask.count {
+        if let remoteSettingLenght = remoteSetting?.lenght, cleanValue.count != remoteSettingLenght {
             return false
         } else {
             switch CardState(fromPrefix: cleanValue) {

--- a/Source/ViewModel/FieldProperty/CardNumberFormFieldProperty.swift
+++ b/Source/ViewModel/FieldProperty/CardNumberFormFieldProperty.swift
@@ -91,11 +91,22 @@ struct CardNumberFormFieldProperty : MLCardFormFieldPropertyProtocol {
     }
     
     func isValid(value: String?) -> Bool {
-//        #if DEBUG
-//        return true
-//        #else
-        guard let value = value, value.count == patternMask()?.count else { return false }
-        let cleanValue = value.replacingOccurrences(of: " ", with: "")
+        guard let value = value else { return false }
+        let cleanValue = value.removingWhitespaceAndNewlines()
+        
+        if let mask = remoteSetting?.mask, value.count == mask.count {
+            return false
+        } else {
+            switch CardState(fromPrefix: cleanValue) {
+            case .identified(let cardType):
+                let cardNumberLength = cardType.segmentGroupings.reduce(0, +)
+                if cleanValue.count != cardNumberLength {
+                    return false
+                }
+            default:
+                return false
+            }
+        }
         
         var sum = 0
         let digitStrings = cleanValue.reversed().map { String($0) }

--- a/Source/ViewModel/FieldProperty/Helpers/CardParser.swift
+++ b/Source/ViewModel/FieldProperty/Helpers/CardParser.swift
@@ -1,0 +1,186 @@
+//
+//  CardParser.swift
+//  MLCardForm
+//
+//  Created by Eric Ertl on 19/12/2019.
+//
+
+import Foundation
+
+enum CardType {
+    case amex
+    case diners
+    case discover
+    case jcb
+    case masterCard
+    case visa
+    
+    static let allValues: [CardType] = [.visa, .masterCard, .amex, .diners, .discover, .jcb]
+    
+    private var validationRequirements: ValidationRequirement {
+        let prefix: [PrefixContainable], length: [Int]
+        
+        switch self {
+            /* // IIN prefixes and length requriements retreived from https://en.wikipedia.org/wiki/Bank_card_number on June 28, 2016 */
+            
+        case .amex:         prefix = ["34", "37"]
+        length = [15]
+            
+        case .diners:       prefix = ["300"..."305", "309", "36", "38"..."39"]
+        length = [14]
+            
+        case .discover:     prefix = ["6011", "65", "644"..."649", "622126"..."622925"]
+        length = [16]
+            
+        case .jcb:          prefix = ["3528"..."3589"]
+        length = [16]
+            
+        case .masterCard:   prefix = ["51"..."55", "2221"..."2720"]
+        length = [16]
+            
+        case .visa:         prefix = ["4"]
+        length = [13, 16, 19]
+            
+        }
+        
+        return ValidationRequirement(prefixes: prefix, lengths: length)
+    }
+    
+    var segmentGroupings: [Int] {
+        switch self {
+        case .amex:      return [4, 6, 5]
+        case .diners:    return [4, 6, 4]
+        default:         return [4, 4, 4, 4]
+        }
+    }
+    
+    var maxLength: Int {
+        return validationRequirements.lengths.max() ?? 16
+    }
+    
+    var cvvLength: Int {
+        switch self {
+        case .amex: return 4
+        default: return 3
+        }
+    }
+    
+    func isValid(_ accountNumber: String) -> Bool {
+        return validationRequirements.isValid(accountNumber) && CardType.luhnCheck(accountNumber)
+    }
+    
+    func isPrefixValid(_ accountNumber: String) -> Bool {
+        return validationRequirements.isPrefixValid(accountNumber)
+    }
+}
+
+fileprivate extension CardType {
+    
+    struct ValidationRequirement {
+        let prefixes: [PrefixContainable]
+        let lengths: [Int]
+        
+        func isValid(_ accountNumber: String) -> Bool {
+            return isLengthValid(accountNumber) && isPrefixValid(accountNumber)
+        }
+        
+        func isPrefixValid(_ accountNumber: String) -> Bool {
+            guard prefixes.count > 0 else { return true }
+            return prefixes.contains { $0.hasCommonPrefix(with: accountNumber) }
+        }
+        
+        func isLengthValid(_ accountNumber: String) -> Bool {
+            guard lengths.count > 0 else { return true }
+            return lengths.contains { accountNumber.count == $0 }
+        }
+    }
+    
+    // from: https://gist.github.com/cwagdev/635ce973e8e86da0403a
+    static func luhnCheck(_ cardNumber: String) -> Bool {
+        var sum = 0
+        let reversedCharacters = cardNumber.reversed().map { String($0) }
+        for (idx, element) in reversedCharacters.enumerated() {
+            guard let digit = Int(element) else { return false }
+            switch ((idx % 2 == 1), digit) {
+            case (true, 9): sum += 9
+            case (true, 0...8): sum += (digit * 2) % 9
+            default: sum += digit
+            }
+        }
+        return sum % 10 == 0
+    }
+    
+}
+
+//MARK: - CardState
+
+enum CardState {
+    case identified(CardType)
+    case indeterminate([CardType])
+    case invalid
+}
+
+extension CardState: Equatable {}
+func ==(lhs: CardState, rhs: CardState) -> Bool {
+    switch (lhs, rhs) {
+    case (.invalid, .invalid): return true
+    case (let .indeterminate(cards1), let .indeterminate(cards2)): return cards1 == cards2
+    case (let .identified(card1), let .identified(card2)): return card1 == card2
+    default: return false
+    }
+}
+
+extension CardState {
+    
+    init(fromNumber number: String) {
+        if let card = CardType.allValues.first(where: { $0.isValid(number) }) {
+            self = .identified(card)
+        }
+        else {
+            self = .invalid
+        }
+    }
+    
+    init(fromPrefix prefix: String) {
+        let possibleTypes = CardType.allValues.filter { $0.isPrefixValid(prefix) }
+        if possibleTypes.count >= 2 {
+            self = .indeterminate(possibleTypes)
+        }
+        else if possibleTypes.count == 1, let card = possibleTypes.first {
+            self = .identified(card)
+        }
+        else {
+            self = .invalid
+        }
+    }
+    
+}
+
+//MARK: - PrefixContainable
+
+fileprivate protocol PrefixContainable {
+    func hasCommonPrefix(with text: String) -> Bool
+}
+
+extension ClosedRange: PrefixContainable {
+    func hasCommonPrefix(with text: String) -> Bool {
+        //cannot include Where clause in protocol conformance, so have to ensure Bound == String :(
+        guard let lower = lowerBound as? String, let upper = upperBound as? String else { return false }
+        
+        let trimmedRange: ClosedRange<String> = {
+            let length = text.count
+            let trimmedStart = String(lower.prefix(length))
+            let trimmedEnd = String(upper.prefix(length))
+            return trimmedStart...trimmedEnd
+        }()
+        
+        let trimmedText = String(text.prefix(trimmedRange.lowerBound.count))
+        return trimmedRange ~= trimmedText
+    }
+}
+
+extension String: PrefixContainable {
+    func hasCommonPrefix(with text: String) -> Bool {
+        return hasPrefix(text) || text.hasPrefix(self)
+    }
+}

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -74,10 +74,7 @@ final class MLCardFormViewModel {
             [MLCardFormField(fieldProperty:IDTypeFormFieldProperty()),
              MLCardFormField(fieldProperty:IDNumberFormFieldProperty())],
         ]
-        cardFormFields?.forEach{ $0.forEach{
-            $0.notifierProtocol = notifierProtocol
-            $0.render()
-        }}
+        setupAndRenderCardFormFields(cardFormFields: cardFormFields, notifierProtocol: notifierProtocol)
     }
 
     func updateCardFormFields(_ remoteSettings: [MLCardFormFieldSetting], notifierProtocol: MLCardFormFieldNotifierProtocol?) {
@@ -110,6 +107,10 @@ final class MLCardFormViewModel {
                 MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, remoteSetting: idNumberSetting, idNumberValue: storedIDNumber))
                 ])
         }
+        setupAndRenderCardFormFields(cardFormFields: cardFormFields, notifierProtocol: notifierProtocol)
+    }
+    
+    func setupAndRenderCardFormFields(cardFormFields: [[MLCardFormField]]?, notifierProtocol: MLCardFormFieldNotifierProtocol?) {
         cardFormFields?.forEach{ $0.forEach{
             $0.notifierProtocol = notifierProtocol
             $0.render()

--- a/Source/ViewModel/Protocols/MLCardFormViewModelProtocol.swift
+++ b/Source/ViewModel/Protocols/MLCardFormViewModelProtocol.swift
@@ -10,6 +10,6 @@ import MLCardDrawer
 
 protocol MLCardFormViewModelProtocol: NSObjectProtocol {
     func shouldUpdateCard(cardUI: CardUI)
-    func shouldUpdateFields(remoteSettings: [MLCardFormFieldSetting])
+    func shouldUpdateFields(remoteSettings: [MLCardFormFieldSetting]?)
     func shouldUpdateAppBarTitle(paymentTypeId: String?)
 }


### PR DESCRIPTION
…ex or Diners

Si el primer request de bin falla, al completar el numero de la tarjeta, no vuelve a hacer el request al hacer tap en "Proximo", si la tarjeta es Amex o Diners que tienen un maxlength diferente al default de 16.
Agregue una clase que detecta offline que tipo de tarjeta es para poder hacer la validacion de maxlength correctamente en estos casos.

La idea era tambien refrescar cardui y la mascara cuando fallaba el 1er request, pero se me complico un poco, asi que decidi solo dejar el fix de la validacion