### PR TITLE
Fixes statusbar to implement MLCardForm in Cards

### DIFF
--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -20,6 +20,7 @@ open class MLCardFormBuilder: NSObject {
     internal var excludedPaymentTypes: [String]?
     internal var navigationCustomBackgroundColor: UIColor?
     internal var navigationCustomTextColor: UIColor?
+    internal var addStatusBarBackground: Bool?
     internal var animateOnLoad: Bool = false
     private var tracker: MLCardFormTracker = MLCardFormTracker.sharedInstance
     
@@ -81,6 +82,16 @@ extension MLCardFormBuilder {
     open func setNavigationBarCustomColor(backgroundColor: UIColor, textColor: UIColor) -> MLCardFormBuilder {
         self.navigationCustomBackgroundColor = backgroundColor
         self.navigationCustomTextColor = textColor
+        return self
+    }
+    
+    /**
+     Determinates if MLCardForm ViewController should be add a view for the statusBar with the color of the navigationBar or not. Default is true.
+     - parameter animated: `Bool`
+     */
+    @discardableResult
+    open func setShouldAddStatusBarBackground(_ addStatusBarBackground: Bool) -> MLCardFormBuilder {
+        self.addStatusBarBackground = addStatusBarBackground
         return self
     }
 

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -173,7 +173,9 @@ private extension MLCardFormViewController {
         title = AppBar.Generic.title
         let (backgroundNavigationColor, textNavigationColor) = viewModel.getNavigationBarCustomColor()
         super.loadStyles(customNavigationBackgroundColor: backgroundNavigationColor, customNavigationTextColor: textNavigationColor)
-        addStatusBarBackground(color: backgroundNavigationColor)
+        if viewModel.shouldAddStatusBarBackground() {
+            addStatusBarBackground(color: backgroundNavigationColor)
+        }
         setupCardContainer()
         setupProgress()
         setupTempTextField()

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -297,6 +297,10 @@ final class MLCardFormViewModel {
     func getNavigationBarCustomColor() -> (backgroundColor: UIColor?, textColor: UIColor?) {
         return (builder?.navigationCustomBackgroundColor, builder?.navigationCustomTextColor)
     }
+    
+    func shouldAddStatusBarBackground() -> Bool {
+        return builder?.addStatusBarBackground ?? true
+    }
 
     func shouldAnimateOnLoad() -> Bool {
         return builder?.animateOnLoad ?? false


### PR DESCRIPTION
Se agrego un param para no agregar la view que hace de statusbar en PX, para evitar que se agregue esa view donde no corresponde en proyectos que no tienen la navegacion extraña de px
Este es un screenshot de como se veia antes del fix cuando se seteaba un color de navbar.
<img width="353" alt="Screen Shot 2020-04-02 at 10 28 54" src="https://user-images.githubusercontent.com/54864543/78261066-1e188180-74d5-11ea-8584-947cebab74ad.png">
