### PR TITLE
Fix LoadingView bug

### DIFF
--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -113,8 +113,10 @@ private extension MLCardFormViewController {
             
             switch result {
             case .success:
-                DispatchQueue.main.async { [weak self] in
-                    self?.hideProgress()
+                if showProggressAndSnackBar {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.hideProgress()
+                    }
                 }
                 break
             case .failure(let error):

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -113,6 +113,9 @@ private extension MLCardFormViewController {
             
             switch result {
             case .success:
+                DispatchQueue.main.async { [weak self] in
+                    self?.hideProgress()
+                }
                 break
             case .failure(let error):
                 // Show error to the user


### PR DESCRIPTION
Cuando se completaba el card Number pero por falta de conexión u otro motivo no se obtenía la info de la card, al tapear en el botón Siguiente se volvía a llamar al endpoint de cardData con la loadingView pero esta nunca se dismiseaba.