### PR TITLE
Feature/flexible navigation customization

### DIFF
--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -33,7 +33,6 @@ open class MLCardFormBuilder: NSObject {
      - parameter siteId: Country Meli/MP Site identifier - Ej: MLA, MLB..
      - parameter flowId: Your flow identifier. Using for tracking and traffic segmentation.
      - parameter lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
-     - parameter configureNavigationBar: Boolean flag specifying if the behavior and aspect of navigation bar should be managed internally. Optional parameter; defaults to true
      */
     public init(publicKey: String, siteId: String, flowId: String, lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = publicKey
@@ -50,7 +49,6 @@ open class MLCardFormBuilder: NSObject {
      - parameter siteId: Country Meli/MP Site identifier - Ej: MLA, MLB..
      - parameter flowId: Your flow identifier. Using for tracking and traffic segmentation.
      - parameter lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
-     - parameter configureNavigationBar: Boolean flag specifying if the behavior and aspect of navigation bar should be managed internally. Optional parameter; defaults to true
      */
     public init(privateKey: String, siteId: String, flowId: String, lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = nil

--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -21,8 +21,8 @@ open class MLCardFormBuilder: NSObject {
     internal var navigationCustomBackgroundColor: UIColor?
     internal var navigationCustomTextColor: UIColor?
     internal var addStatusBarBackground: Bool?
-    internal let shouldConfigureNavigationBar: Bool?
     internal var animateOnLoad: Bool = false
+    internal var shouldConfigureNavigation: Bool?
     private var tracker: MLCardFormTracker = MLCardFormTracker.sharedInstance
     
     // MARK: Initialization
@@ -35,18 +35,12 @@ open class MLCardFormBuilder: NSObject {
      - parameter lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
      - parameter configureNavigationBar: Boolean flag specifying if the behavior and aspect of navigation bar should be managed internally. Optional parameter; defaults to true
      */
-    public init(publicKey: String,
-                siteId: String,
-                flowId: String,
-                lifeCycleDelegate: MLCardFormLifeCycleDelegate,
-                configureNavigationBar: Bool = true)
-    {
+    public init(publicKey: String, siteId: String, flowId: String, lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = publicKey
         self.siteId = siteId
         self.flowId = flowId
         self.privateKey = nil
         self.lifeCycleDelegate = lifeCycleDelegate
-        self.shouldConfigureNavigationBar = configureNavigationBar
         tracker.set(flowId: flowId, siteId: siteId)
     }
     
@@ -58,18 +52,12 @@ open class MLCardFormBuilder: NSObject {
      - parameter lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
      - parameter configureNavigationBar: Boolean flag specifying if the behavior and aspect of navigation bar should be managed internally. Optional parameter; defaults to true
      */
-    public init(privateKey: String,
-                siteId: String,
-                flowId: String,
-                lifeCycleDelegate: MLCardFormLifeCycleDelegate,
-                configureNavigationBar: Bool = true)
-    {
+    public init(privateKey: String, siteId: String, flowId: String, lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = nil
         self.privateKey = privateKey
         self.siteId = siteId
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
-        self.shouldConfigureNavigationBar = configureNavigationBar
         tracker.set(flowId: flowId, siteId: siteId)
     }
 }
@@ -107,6 +95,16 @@ extension MLCardFormBuilder {
     @discardableResult
     open func setShouldAddStatusBarBackground(_ addStatusBarBackground: Bool) -> MLCardFormBuilder {
         self.addStatusBarBackground = addStatusBarBackground
+        return self
+    }
+
+    /**
+     Determinates if MLCardForm ViewController should be in charge of configuring navigation. Default is true.
+     - parameter configureNavigation: `Bool`
+     */
+    @discardableResult
+    open func setShouldConfigureNavigation(_ configureNavigation: Bool) -> MLCardFormBuilder {
+        self.shouldConfigureNavigation = configureNavigation
         return self
     }
 

--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -21,7 +21,7 @@ open class MLCardFormBuilder: NSObject {
     internal var navigationCustomBackgroundColor: UIColor?
     internal var navigationCustomTextColor: UIColor?
     internal var addStatusBarBackground: Bool?
-    internal var shouldConfigureNavigationBar: Bool?
+    internal let shouldConfigureNavigationBar: Bool?
     internal var animateOnLoad: Bool = false
     private var tracker: MLCardFormTracker = MLCardFormTracker.sharedInstance
     
@@ -33,13 +33,20 @@ open class MLCardFormBuilder: NSObject {
      - parameter siteId: Country Meli/MP Site identifier - Ej: MLA, MLB..
      - parameter flowId: Your flow identifier. Using for tracking and traffic segmentation.
      - parameter lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
+     - parameter configureNavigationBar: Boolean flag specifying if the behavior and aspect of navigation bar should be managed internally. Optional parameter; defaults to true
      */
-    public init(publicKey: String, siteId: String, flowId: String, lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
+    public init(publicKey: String,
+                siteId: String,
+                flowId: String,
+                lifeCycleDelegate: MLCardFormLifeCycleDelegate,
+                configureNavigationBar: Bool = true)
+    {
         self.publicKey = publicKey
         self.siteId = siteId
         self.flowId = flowId
         self.privateKey = nil
         self.lifeCycleDelegate = lifeCycleDelegate
+        self.shouldConfigureNavigationBar = configureNavigationBar
         tracker.set(flowId: flowId, siteId: siteId)
     }
     
@@ -49,13 +56,20 @@ open class MLCardFormBuilder: NSObject {
      - parameter siteId: Country Meli/MP Site identifier - Ej: MLA, MLB..
      - parameter flowId: Your flow identifier. Using for tracking and traffic segmentation.
      - parameter lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
+     - parameter configureNavigationBar: Boolean flag specifying if the behavior and aspect of navigation bar should be managed internally. Optional parameter; defaults to true
      */
-    public init(privateKey: String, siteId: String, flowId: String, lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
+    public init(privateKey: String,
+                siteId: String,
+                flowId: String,
+                lifeCycleDelegate: MLCardFormLifeCycleDelegate,
+                configureNavigationBar: Bool = true)
+    {
         self.publicKey = nil
         self.privateKey = privateKey
         self.siteId = siteId
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
+        self.shouldConfigureNavigationBar = configureNavigationBar
         tracker.set(flowId: flowId, siteId: siteId)
     }
 }

--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -21,6 +21,7 @@ open class MLCardFormBuilder: NSObject {
     internal var navigationCustomBackgroundColor: UIColor?
     internal var navigationCustomTextColor: UIColor?
     internal var addStatusBarBackground: Bool?
+    internal var shouldConfigureNavigationBar: Bool?
     internal var animateOnLoad: Bool = false
     private var tracker: MLCardFormTracker = MLCardFormTracker.sharedInstance
     

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -197,11 +197,13 @@ private extension MLCardFormViewController {
     }
     
     func initialSetup() {
-        title = AppBar.Generic.title
-        let (backgroundNavigationColor, textNavigationColor) = viewModel.getNavigationBarCustomColor()
-        super.loadStyles(customNavigationBackgroundColor: backgroundNavigationColor, customNavigationTextColor: textNavigationColor)
-        if viewModel.shouldAddStatusBarBackground() {
-            addStatusBarBackground(color: backgroundNavigationColor)
+        if viewModel.shouldConfigureNavigationBar() {
+            title = AppBar.Generic.title
+            let (backgroundNavigationColor, textNavigationColor) = viewModel.getNavigationBarCustomColor()
+            super.loadStyles(customNavigationBackgroundColor: backgroundNavigationColor, customNavigationTextColor: textNavigationColor)
+            if viewModel.shouldAddStatusBarBackground() {
+                addStatusBarBackground(color: backgroundNavigationColor)
+            }
         }
         setupCardContainer()
         setupProgress()

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -298,6 +298,10 @@ final class MLCardFormViewModel {
         return (builder?.navigationCustomBackgroundColor, builder?.navigationCustomTextColor)
     }
     
+    func shouldConfigureNavigationBar() -> Bool {
+        return builder?.shouldConfigureNavigationBar ?? true
+    }
+
     func shouldAddStatusBarBackground() -> Bool {
         return builder?.addStatusBarBackground ?? true
     }

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -299,7 +299,7 @@ final class MLCardFormViewModel {
     }
     
     func shouldConfigureNavigationBar() -> Bool {
-        return builder?.shouldConfigureNavigationBar ?? true
+        return builder?.shouldConfigureNavigation ?? true
     }
 
     func shouldAddStatusBarBackground() -> Bool {


### PR DESCRIPTION
En la iniciativa de OneTap queremos utilizar esta librería para dar de alta tarjetas. El problema original que teníamos era que por cómo estamos presentando las vistas allí, necesitábamos que el back hiciese un dismiss del view controller en vez de un pop como está hecho en la lib. Además necesitábamos usar un ícono ligeramente distinto para el back button, no mostrar título y algunos otros detalles.

En este PR se agrega un parámetro opcional `shouldConfigureNavigationBar` al builder. Si el valor es `true` entonces esta lib se encarga de manejar la configuración de la barra de navegación y las acciones asociadas tal cual hace hasta el momento.
Si quien consume la lib le pasa `false`, deber ser el consumidor quién configure todo lo relacionado a la navegación.