### PR TITLE
Leave title management to CardForm

### DIFF
--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -197,8 +197,8 @@ private extension MLCardFormViewController {
     }
     
     func initialSetup() {
+        title = AppBar.Generic.title
         if viewModel.shouldConfigureNavigationBar() {
-            title = AppBar.Generic.title
             let (backgroundNavigationColor, textNavigationColor) = viewModel.getNavigationBarCustomColor()
             super.loadStyles(customNavigationBackgroundColor: backgroundNavigationColor, customNavigationTextColor: textNavigationColor)
             if viewModel.shouldAddStatusBarBackground() {


### PR DESCRIPTION
En el PR #50 se introdujo un flag para permitir la customización de la apariencia y performer del back button en la barra de navegación. Eso se hizo ya que al presentar el card form desde la iniciativa de One Tap necesitábamos una apariencia distinta.
En aquel momento la especificación de UX decía que iba sin título, pero ahora cambió y quieren que lleve el que "calcula" CardForm.
Así que este PR lo que hace es sacar el seteo del título de la navigation fuera del condicional que chequea si CardForm debe configurar o no la navigation bar.