### PR TITLE
Nuevo firma publica dismissLoading

### DIFF
--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -70,6 +70,12 @@ open class MLCardFormViewController: MLCardFormBaseViewController {
             if let completion = completion { completion() }
         })
     }
+    
+    open func dismissLoading(completion: (() -> Void)? = nil) {
+        hideProgress(completion: { [weak self] in
+            if let completion = completion { completion() }
+        })
+    }
 }
 
 // MARK: Public API.


### PR DESCRIPTION
Para la iniciativa de SplitPayment al terminar de cargar la tarjeta avanzamos a una nueva pantalla. 
La función expuesta para cerrar el loading también hacia un pop y eso provocaba un comportamiento no esperado.

| Con pop | Sin pop | 
| --- | --- |
| ![addNewCard_pop](https://user-images.githubusercontent.com/46828246/117491488-a8d47700-af46-11eb-862d-dde5bd399b20.gif) |  ![addNewCard](https://user-images.githubusercontent.com/46828246/117491522-b12cb200-af46-11eb-8c6b-d47c82fb48be.gif) |