### PR TITLE
nuevo request para validar bin para marketplace

### DIFF
--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -38,14 +38,30 @@ open class MLCardFormBuilder: NSObject {
     public init(publicKey: String,
                 siteId: String,
                 flowId: String,
-                lifeCycleDelegate: MLCardFormLifeCycleDelegate,
-                cardInfoMarketplace:MLCardFormCardInformationMarketplace? = nil) {
+                lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = publicKey
         self.privateKey = nil
         self.siteId = siteId
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
-        self.cardInfoMarketplace = cardInfoMarketplace
+        self.cardInfoMarketplace = nil
+        tracker.set(flowId: flowId, siteId: siteId)
+    }
+    
+    /// Mandatory init.
+    /// - Parameters:
+    ///   - publicKey: Merchant public key / collector public key
+    ///   - cardInformation: Information related to the card and the transaction you will carry out with it.
+    ///   - lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
+    public init(publicKey: String,
+                cardInformation:MLCardFormCardInformationMarketplace,
+                lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
+        self.publicKey = publicKey
+        self.privateKey = nil
+        self.siteId = cardInformation.siteId
+        self.flowId = cardInformation.flowId
+        self.lifeCycleDelegate = lifeCycleDelegate
+        self.cardInfoMarketplace = cardInformation
         tracker.set(flowId: flowId, siteId: siteId)
     }
     
@@ -59,14 +75,30 @@ open class MLCardFormBuilder: NSObject {
     public init(privateKey: String,
                 siteId: String,
                 flowId: String,
-                lifeCycleDelegate: MLCardFormLifeCycleDelegate,
-                cardInfoMarketplace:MLCardFormCardInformationMarketplace? = nil) {
+                lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = nil
         self.privateKey = privateKey
         self.siteId = siteId
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
-        self.cardInfoMarketplace = cardInfoMarketplace
+        self.cardInfoMarketplace = nil
+        tracker.set(flowId: flowId, siteId: siteId)
+    }
+    
+    /// Mandatory init.
+    /// - Parameters:
+    ///   - privateKey: Logged access token - user key
+    ///   - cardInformation: Information related to the card and the transaction you will carry out with it.
+    ///   - lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
+    public init(privateKey: String,
+                cardInformation:MLCardFormCardInformationMarketplace,
+                lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
+        self.publicKey = nil
+        self.privateKey = privateKey
+        self.siteId = cardInformation.siteId
+        self.flowId = cardInformation.flowId
+        self.lifeCycleDelegate = lifeCycleDelegate
+        self.cardInfoMarketplace = cardInformation
         tracker.set(flowId: flowId, siteId: siteId)
     }
     

--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -17,6 +17,7 @@ open class MLCardFormBuilder: NSObject {
     internal let privateKey: String?
     internal let flowId: String
     internal let siteId: String
+    internal let cardInfoMarketplace: MLCardFormCardInformationMarketplace?
     internal var excludedPaymentTypes: [String]?
     internal var navigationCustomBackgroundColor: UIColor?
     internal var navigationCustomTextColor: UIColor?
@@ -34,12 +35,17 @@ open class MLCardFormBuilder: NSObject {
      - parameter flowId: Your flow identifier. Using for tracking and traffic segmentation.
      - parameter lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
      */
-    public init(publicKey: String, siteId: String, flowId: String, lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
+    public init(publicKey: String,
+                siteId: String,
+                flowId: String,
+                lifeCycleDelegate: MLCardFormLifeCycleDelegate,
+                cardInfoMarketplace:MLCardFormCardInformationMarketplace? = nil) {
         self.publicKey = publicKey
         self.privateKey = nil
         self.siteId = siteId
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
+        self.cardInfoMarketplace = cardInfoMarketplace
         tracker.set(flowId: flowId, siteId: siteId)
     }
     
@@ -50,12 +56,17 @@ open class MLCardFormBuilder: NSObject {
      - parameter flowId: Your flow identifier. Using for tracking and traffic segmentation.
      - parameter lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
      */
-    public init(privateKey: String, siteId: String, flowId: String, lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
+    public init(privateKey: String,
+                siteId: String,
+                flowId: String,
+                lifeCycleDelegate: MLCardFormLifeCycleDelegate,
+                cardInfoMarketplace:MLCardFormCardInformationMarketplace? = nil) {
         self.publicKey = nil
         self.privateKey = privateKey
         self.siteId = siteId
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
+        self.cardInfoMarketplace = cardInfoMarketplace
         tracker.set(flowId: flowId, siteId: siteId)
     }
     

--- a/Source/Model/BinData/MLCardFormCardInformationMarketplace.swift
+++ b/Source/Model/BinData/MLCardFormCardInformationMarketplace.swift
@@ -1,0 +1,25 @@
+//
+//  MLCardFormCardInformationMarketplace.swift
+//  MLCardForm
+//
+//  Created by Cristian Enrrique Sarmiento Cabarcas on 19/05/21.
+//
+
+import Foundation
+
+
+public struct MLCardFormCardInformationMarketplace: Codable {
+    let flowId: String
+    let vertical: String
+    let flowType: String
+    var bin: String
+    let callerId: String
+    let clientId: String
+    let siteId: String
+    let odr: Bool
+    let items: Array<ItemForCardInfoMarketplace>
+}
+
+public struct ItemForCardInfoMarketplace: Codable {
+    let id:String
+}

--- a/Source/Model/BinData/MLCardFormCardInformationMarketplace.swift
+++ b/Source/Model/BinData/MLCardFormCardInformationMarketplace.swift
@@ -18,8 +18,31 @@ public struct MLCardFormCardInformationMarketplace: Codable {
     let siteId: String
     let odr: Bool
     let items: Array<ItemForCardInfoMarketplace>
+    
+    init(flowId: String,
+         vertical: String,
+         flowType: String,
+         bin: String,
+         callerId: String,
+         clientId: String,
+         siteId: String,
+         odr: Bool,
+         items: Array<ItemForCardInfoMarketplace>) {
+        self.flowId = flowId
+        self.vertical = vertical
+        self.flowType = flowType
+        self.bin = bin
+        self.callerId = callerId
+        self.clientId = clientId
+        self.siteId = siteId
+        self.odr = odr
+        self.items = items
+    }
 }
 
 public struct ItemForCardInfoMarketplace: Codable {
     let id:String
+    init(id:String) {
+        self.id = id
+    }
 }

--- a/Source/Model/BinData/MLCardFormCardInformationMarketplace.swift
+++ b/Source/Model/BinData/MLCardFormCardInformationMarketplace.swift
@@ -19,6 +19,17 @@ public struct MLCardFormCardInformationMarketplace: Codable {
     let odr: Bool
     let items: Array<ItemForCardInfoMarketplace>
     
+    /// init
+    /// - Parameters:
+    ///   - flowId: Your flow identifier. Using for tracking and traffic segmentation.
+    ///   - vertical: Your vertical identifier. Using for tracking and traffic segmentation.
+    ///   - flowType: Your flow type. Using for tracking and traffic segmentation.
+    ///   - bin: First six numbers of the card (it must be sent empty and they are entered automatically)
+    ///   - callerId: caller Id  used in service
+    ///   - clientId: client Id  used in service
+    ///   - siteId: Country Meli/MP Site identifier - Ej: MLA, MLB..
+    ///   - odr: Indicate whether to get ODR icon
+    ///   - items: List of items that are being used in the checkout flow
     public init(flowId: String,
                 vertical: String,
                 flowType: String,

--- a/Source/Model/BinData/MLCardFormCardInformationMarketplace.swift
+++ b/Source/Model/BinData/MLCardFormCardInformationMarketplace.swift
@@ -19,15 +19,15 @@ public struct MLCardFormCardInformationMarketplace: Codable {
     let odr: Bool
     let items: Array<ItemForCardInfoMarketplace>
     
-    init(flowId: String,
-         vertical: String,
-         flowType: String,
-         bin: String,
-         callerId: String,
-         clientId: String,
-         siteId: String,
-         odr: Bool,
-         items: Array<ItemForCardInfoMarketplace>) {
+    public init(flowId: String,
+                vertical: String,
+                flowType: String,
+                bin: String,
+                callerId: String,
+                clientId: String,
+                siteId: String,
+                odr: Bool,
+                items: Array<ItemForCardInfoMarketplace>) {
         self.flowId = flowId
         self.vertical = vertical
         self.flowType = flowType
@@ -42,7 +42,7 @@ public struct MLCardFormCardInformationMarketplace: Codable {
 
 public struct ItemForCardInfoMarketplace: Codable {
     let id:String
-    init(id:String) {
+    public init(id:String) {
         self.id = id
     }
 }

--- a/Source/Network/Router/MLCardFormApiRouter.swift
+++ b/Source/Network/Router/MLCardFormApiRouter.swift
@@ -51,11 +51,17 @@ enum MLCardFormApiRouter {
 
     var headers: [String : String]? {
         switch self {
-        case .getCardData(_ , let headers), .getCardDataFromMarketplace(_, let headers):
+        case .getCardData(_ , let headers):
             return [MLCardFormBinService.HeadersKeys.userAgent.getKey: headers.userAgent,
                     MLCardFormBinService.HeadersKeys.xDensity.getKey: headers.xDensity,
                     MLCardFormBinService.HeadersKeys.acceptLanguage.getKey: headers.acceptLanguage,
                     MLCardFormBinService.HeadersKeys.xProductId.getKey: headers.xProductId]
+        case .getCardDataFromMarketplace(_, let headers):
+            return [MLCardFormBinService.HeadersKeys.userAgent.getKey: headers.userAgent,
+                    MLCardFormBinService.HeadersKeys.xDensity.getKey: headers.xDensity,
+                    MLCardFormBinService.HeadersKeys.acceptLanguage.getKey: headers.acceptLanguage,
+                    MLCardFormBinService.HeadersKeys.xProductId.getKey: headers.xProductId,
+                    MLCardFormBinService.HeadersKeys.contentType.getKey: headers.contentType ?? ""]
         case .postCardTokenData(_, let headers, _),
              .postCardData(_, let headers, _):
             return [MLCardFormAddCardService.HeadersKeys.contentType.getKey: headers.contentType]

--- a/Source/Network/Router/MLCardFormApiRouter.swift
+++ b/Source/Network/Router/MLCardFormApiRouter.swift
@@ -15,17 +15,19 @@ enum MLCardFormApiRouter {
     case postCardData(MLCardFormAddCardService.AccessTokenParam, MLCardFormAddCardService.Headers, MLCardFormAddCardBody)
     case getWebPayInitInscription(MLCardFormWebPayService.AccessTokenParam, MLCardFormWebPayService.Headers)
     case postWebPayFinishInscription(MLCardFormWebPayService.AccessTokenParam, MLCardFormWebPayService.Headers, MLCardFormFinishInscriptionBody)
+    case getCardDataFromMarketplace(MLCardFormCardInformationMarketplace,
+                                    MLCardFormBinService.Headers)
 
     var scheme: String {
         switch self {
-        case .getCardData, .postCardTokenData, .postCardData, .getWebPayInitInscription, .postWebPayFinishInscription:
+        case .getCardData, .postCardTokenData, .postCardData, .getWebPayInitInscription, .postWebPayFinishInscription, .getCardDataFromMarketplace:
             return "https"
         }
     }
 
     var host: String {
         switch self {
-        case .getCardData, .postCardTokenData, .postCardData, .getWebPayInitInscription, .postWebPayFinishInscription:
+        case .getCardData, .postCardTokenData, .postCardData, .getWebPayInitInscription, .postWebPayFinishInscription, .getCardDataFromMarketplace:
             return "api.mercadopago.com"
         }
     }
@@ -42,12 +44,14 @@ enum MLCardFormApiRouter {
             return "/production/px_mobile/v1/card_webpay/inscription/init"
         case .postWebPayFinishInscription:
             return "/production/px_mobile/v1/card_webpay/inscription/finish"
+        case .getCardDataFromMarketplace:
+            return "/production/px_mobile/v1/card/marketplace"
         }
     }
 
     var headers: [String : String]? {
         switch self {
-        case .getCardData(_ , let headers):
+        case .getCardData(_ , let headers), .getCardDataFromMarketplace(_, let headers):
             return [MLCardFormBinService.HeadersKeys.userAgent.getKey: headers.userAgent,
                     MLCardFormBinService.HeadersKeys.xDensity.getKey: headers.xDensity,
                     MLCardFormBinService.HeadersKeys.acceptLanguage.getKey: headers.acceptLanguage,
@@ -96,6 +100,8 @@ enum MLCardFormApiRouter {
                 URLQueryItem(name: MLCardFormAddCardService.QueryKeys.accessToken.getKey, value: queryParams.accessToken),
             ]
             return urlQueryItems
+        case .getCardDataFromMarketplace(_):
+            return [];
         }
     }
 
@@ -106,7 +112,8 @@ enum MLCardFormApiRouter {
             return "GET"
         case .postCardTokenData,
              .postCardData,
-             .postWebPayFinishInscription:
+             .postWebPayFinishInscription,
+             .getCardDataFromMarketplace:
             return "POST"
         }
     }
@@ -118,6 +125,8 @@ enum MLCardFormApiRouter {
         case .postCardData(_, _, let body):
             return encode(body)
         case .postWebPayFinishInscription(_, _, let body):
+            return encode(body)
+        case .getCardDataFromMarketplace(let body, _):
             return encode(body)
         default:
             return nil

--- a/Source/Network/Services/MLCardFormBinService.swift
+++ b/Source/Network/Services/MLCardFormBinService.swift
@@ -25,11 +25,16 @@ final class MLCardFormBinService {
     private let queue = OperationQueue()
     private var lastBin: String?
     private var lastResponse: MLCardFormBinData?
+    private var cardInfoMarketplace: MLCardFormCardInformationMarketplace?
     
-    func update(siteId: String?, excludedPaymentTypes: [String]?, flowId: String?) {
+    func update(siteId: String?,
+                excludedPaymentTypes: [String]?,
+                flowId: String?,
+                cardInfoMarketplace:MLCardFormCardInformationMarketplace?) {
         self.siteId = siteId
         self.excludedPaymentTypes = excludedPaymentTypes
         self.flowId = flowId
+        self.cardInfoMarketplace = cardInfoMarketplace
     }
     
     private func getAppName() -> String {
@@ -132,24 +137,22 @@ extension MLCardFormBinService {
         }
 
         debugLog("Bin data New call: Operation -> \(binNumber)")
-        let queryParams = MLCardFormBinService.QueryParams(bin: binNumber, siteId: siteId, platform: getPlatform(), excludedPaymentTypes: excludedPaymentTypesJoined, odr: true)
         let headers = MLCardFormBinService.Headers(userAgent: "PX/iOS/4.3.4", xDensity: "xxxhdpi", acceptLanguage: MLCardFormLocalizatorManager.shared.getLanguage(), xProductId: getFlowId())
         let operation = BlockOperation(block: {
-            NetworkLayer.request(router: MLCardFormApiRouter.getCardData(queryParams, headers)) { [weak self] (result: Result<MLCardFormBinData, Error>) in
-                guard let self = self else { return }
-                switch result {
-                case .success(let cardFormBinData):
-                    MLCardFormConfiguratorManager.updateConfig(escEnabled: cardFormBinData.escEnabled)
-                    self.lastBin = queryParams.bin
-                    self.lastResponse = cardFormBinData
-                case .failure(let error):
-                    self.debugLog(error)
-                }
-                completion?(result)
+            if  self.getFlowId().contains("chekout-on") ?? false, var cardInfo = self.cardInfoMarketplace {
+                cardInfo.bin = binNumber
+                self.getCardDataMarketplace(cardInfo: cardInfo,
+                                            headers: headers,
+                                            completion: completion)
+            } else {
+                let queryParams = MLCardFormBinService.QueryParams(bin: binNumber, siteId: siteId, platform: self.getPlatform(), excludedPaymentTypes: excludedPaymentTypesJoined, odr: true)
+                self.getCardData(queryParams: queryParams,
+                                 headers: headers,
+                                 completion: completion)
             }
         })
 
-        operation.name = queryParams.bin
+        operation.name = binNumber
         operation.completionBlock = { [weak self] in
             if let name = operation.name {
                 self?.debugLog("Operation is completed -> \(name)")
@@ -161,6 +164,46 @@ extension MLCardFormBinService {
 
 // MARK: Privates
 private extension MLCardFormBinService {
+    
+    func getCardData (queryParams: MLCardFormBinService.QueryParams,
+                      headers:Headers,
+                      completion: ((Result<MLCardFormBinData, Error>) -> ())? = nil) {
+
+        NetworkLayer.request(router: MLCardFormApiRouter.getCardData(queryParams, headers))
+        { [weak self] (result: Result<MLCardFormBinData, Error>) in
+            guard let self = self else { return }
+            switch result {
+            case .success(let cardFormBinData):
+                MLCardFormConfiguratorManager.updateConfig(escEnabled: cardFormBinData.escEnabled)
+                self.lastBin = queryParams.bin
+                self.lastResponse = cardFormBinData
+            case .failure(let error):
+                self.debugLog(error)
+            }
+            completion?(result)
+        }
+        
+    }
+    
+    func getCardDataMarketplace (cardInfo: MLCardFormCardInformationMarketplace,
+                                 headers:Headers,
+                                 completion: ((Result<MLCardFormBinData, Error>) -> ())? = nil) {
+
+        NetworkLayer.request(router: MLCardFormApiRouter.getCardDataFromMarketplace(cardInfo, headers))
+        {  [weak self] (result: Result<MLCardFormBinData, Error>) in
+            guard let self = self else { return }
+            switch result {
+            case .success(let cardFormBinData):
+                MLCardFormConfiguratorManager.updateConfig(escEnabled: cardFormBinData.escEnabled)
+                self.lastBin = cardInfo.bin
+                self.lastResponse = cardFormBinData
+            case .failure(let error):
+                self.debugLog(error)
+            }
+            completion?(result)
+        }
+    }
+    
     func getFlowId() -> String {
         return flowId ?? "MLCardForm"
     }

--- a/Source/Network/Services/MLCardFormBinService.swift
+++ b/Source/Network/Services/MLCardFormBinService.swift
@@ -60,6 +60,7 @@ extension MLCardFormBinService {
         case xDensity
         case acceptLanguage
         case xProductId
+        case contentType
 
         var getKey: String {
             switch self {
@@ -71,6 +72,8 @@ extension MLCardFormBinService {
                 return "accept-language"
             case .xProductId:
                 return "x-product-id"
+            case .contentType:
+                return "content-type"
             }
         }
     }
@@ -80,6 +83,7 @@ extension MLCardFormBinService {
         let xDensity: String
         let acceptLanguage: String
         let xProductId: String
+        let contentType:String?
     }
 
     enum QueryKeys {
@@ -137,17 +141,14 @@ extension MLCardFormBinService {
         }
 
         debugLog("Bin data New call: Operation -> \(binNumber)")
-        let headers = MLCardFormBinService.Headers(userAgent: "PX/iOS/4.3.4", xDensity: "xxxhdpi", acceptLanguage: MLCardFormLocalizatorManager.shared.getLanguage(), xProductId: getFlowId())
         let operation = BlockOperation(block: {
             if  self.getFlowId().contains("chekout-on") ?? false, var cardInfo = self.cardInfoMarketplace {
                 cardInfo.bin = binNumber
                 self.getCardDataMarketplace(cardInfo: cardInfo,
-                                            headers: headers,
                                             completion: completion)
             } else {
                 let queryParams = MLCardFormBinService.QueryParams(bin: binNumber, siteId: siteId, platform: self.getPlatform(), excludedPaymentTypes: excludedPaymentTypesJoined, odr: true)
                 self.getCardData(queryParams: queryParams,
-                                 headers: headers,
                                  completion: completion)
             }
         })
@@ -166,9 +167,9 @@ extension MLCardFormBinService {
 private extension MLCardFormBinService {
     
     func getCardData (queryParams: MLCardFormBinService.QueryParams,
-                      headers:Headers,
                       completion: ((Result<MLCardFormBinData, Error>) -> ())? = nil) {
 
+        let headers = MLCardFormBinService.Headers(userAgent: "PX/iOS/4.3.4", xDensity: "xxxhdpi", acceptLanguage: MLCardFormLocalizatorManager.shared.getLanguage(), xProductId: getFlowId(), contentType: nil)
         NetworkLayer.request(router: MLCardFormApiRouter.getCardData(queryParams, headers))
         { [weak self] (result: Result<MLCardFormBinData, Error>) in
             guard let self = self else { return }
@@ -182,12 +183,16 @@ private extension MLCardFormBinService {
             }
             completion?(result)
         }
-        
     }
     
     func getCardDataMarketplace (cardInfo: MLCardFormCardInformationMarketplace,
-                                 headers:Headers,
                                  completion: ((Result<MLCardFormBinData, Error>) -> ())? = nil) {
+
+        let headers = MLCardFormBinService.Headers(userAgent: "PX/iOS/4.3.4",
+                                                   xDensity: "xxxhdpi",
+                                                   acceptLanguage: MLCardFormLocalizatorManager.shared.getLanguage(),
+                                                   xProductId: getFlowId(),
+                                                   contentType: "application/json")
 
         NetworkLayer.request(router: MLCardFormApiRouter.getCardDataFromMarketplace(cardInfo, headers))
         {  [weak self] (result: Result<MLCardFormBinData, Error>) in

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -59,7 +59,7 @@ final class MLCardFormViewModel {
     func updateWithBuilder(_ builder: MLCardFormBuilder) {
         self.builder = builder
         serviceManager.addCardService.update(publicKey: builder.publicKey, privateKey: builder.privateKey)
-        serviceManager.binService.update(siteId: builder.siteId, excludedPaymentTypes: builder.excludedPaymentTypes, flowId: builder.flowId)
+        serviceManager.binService.update(siteId: builder.siteId, excludedPaymentTypes: builder.excludedPaymentTypes, flowId: builder.flowId, cardInfoMarketplace: builder.cardInfoMarketplace)
     }
     
     func setupDefaultCardFormFields(notifierProtocol: MLCardFormFieldNotifierProtocol?) {


### PR DESCRIPTION
### Descripción
Se agrega otro request para validar qué tarjetas están habilitadas para el item a comprar (filtrado de los bines) y mostrar mensaje de error de ser necesario.

Para el uso de este request se valida a partir de un objeto creado `MLCardFormCardInformationMarketplace` y que el `flowId` contenga como substring "chekout-on". De no cumplir la condifición se usa el request habitual.

### Screenshots
|Tarjeta valida|Tarjeta no valida|
|-----|-----|
|![ezgif com-gif-maker (45)](https://user-images.githubusercontent.com/23064635/119159970-68ccc400-ba1d-11eb-9c1a-3527ed071fa6.gif)|![ezgif com-gif-maker (46)](https://user-images.githubusercontent.com/23064635/119160193-9c0f5300-ba1d-11eb-93f1-029471bec5e0.gif)|