### PR TITLE
Result with bin and payment_type

### DIFF
--- a/Source/Core/LifeCycle/MLCardFormLifeCycleDelegate.swift
+++ b/Source/Core/LifeCycle/MLCardFormLifeCycleDelegate.swift
@@ -15,6 +15,13 @@ import Foundation
      A new credit card has been added sucesfully.
      */
     @objc func didAddCard(cardID: String)
+    
+    /**
+     A new credit card has been added sucesfully.
+     Returns card information
+     */
+    @objc optional func didAddCardInformation(cardInformation: MLCardFormCardInformation)
+    
     /**
      There was an error adding a new credit card.
      */
@@ -25,4 +32,5 @@ extension MLCardFormLifeCycleDelegate {
     func didFailAddCard() {
         //this is a empty implementation to allow this method to be optional
     }
+   
 }

--- a/Source/Model/AddCardData/MLCardFormCardInformation.swift
+++ b/Source/Model/AddCardData/MLCardFormCardInformation.swift
@@ -1,0 +1,35 @@
+//
+//  MLCardFormCardInformation.swift
+//  Pods
+//
+//  Created by Romina Pamela Cortazzo on 2/6/21.
+//
+
+import Foundation
+
+@objc public class MLCardFormCardInformation: NSObject {
+    
+    var cardId: String = ""
+    var paymentType: String = ""
+    var bin: String = ""
+    
+    init(cardId: String, paymentType: String, bin:String){
+        self.cardId = cardId
+        self.paymentType = paymentType
+        self.bin = bin
+    }
+    
+    override init() {}
+    
+    public func getCardId() -> String {
+        return cardId
+    }
+    
+    public func getBin() -> String {
+        return bin
+    }
+    
+    public func getPaymentType() -> String {
+        return paymentType
+    }
+}

--- a/Source/Model/AddCardData/MLCardFormCardInformation.swift
+++ b/Source/Model/AddCardData/MLCardFormCardInformation.swift
@@ -12,11 +12,13 @@ import Foundation
     var cardId: String = ""
     var paymentType: String = ""
     var bin: String = ""
+    var lastFourDigits: String = ""
     
-    init(cardId: String, paymentType: String, bin:String){
+    init(cardId: String, paymentType: String, bin:String, lastFourDigits:String){
         self.cardId = cardId
         self.paymentType = paymentType
         self.bin = bin
+        self.lastFourDigits = lastFourDigits
     }
     
     override init() {}
@@ -31,5 +33,9 @@ import Foundation
     
     public func getPaymentType() -> String {
         return paymentType
+    }
+    
+    public func getLastFourDigits() -> String {
+        return lastFourDigits
     }
 }

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -164,14 +164,17 @@ private extension MLCardFormViewController {
     
     func addCard() {
         showProgress()
-        viewModel.addCard(completion: { (result: Result<String, Error>) in
+        viewModel.addCard(completion: { (result: Result<MLCardFormCardInformation, Error>) in
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 var title: String?
                 switch result {
-                case .success(let cardID):
+                case .success(let cardInformation):
+                    
                     // Notify listener
-                    self.lifeCycleDelegate?.didAddCard(cardID: cardID)
+                    self.lifeCycleDelegate?.didAddCardInformation?(cardInformation: cardInformation)
+                    self.lifeCycleDelegate?.didAddCard(cardID: cardInformation.getCardId())
+                  
                 case .failure(let error):
                     self.hideProgress(completion: { [weak self] in
                         guard let self = self else { return }

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -398,7 +398,8 @@ extension MLCardFormViewModel {
                                                                                  "payment_method_id": paymentMethodId,
                                                                                  "payment_type_id": paymentTypeId])
                         self.saveDataForReuse()
-                        var cardInformation = MLCardFormCardInformation(cardId: addCardData.getId(), paymentType: paymentTypeId, bin: bin)
+                        let lastFourDigits = tokenCardData.lastFourDigits ?? ""
+                        var cardInformation = MLCardFormCardInformation(cardId: addCardData.getId(), paymentType: paymentTypeId, bin: bin, lastFourDigits: lastFourDigits)
                         completion?(.success(cardInformation))
                     case .failure(let error):
                         if case

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -370,7 +370,7 @@ extension MLCardFormViewModel {
         })
     }
 
-    func addCard(completion: ((Result<String, Error>) -> ())? = nil) {
+    func addCard(completion: ((Result<MLCardFormCardInformation, Error>) -> ())? = nil) {
         guard let tokenizationData = getTokenizationData(), let addCardData = getAddCardData() else {
             completion?(.failure(NSError(domain: "MLCardForm", code: 0, userInfo: nil) as Error))
             return
@@ -398,10 +398,12 @@ extension MLCardFormViewModel {
                                                                                  "payment_method_id": paymentMethodId,
                                                                                  "payment_type_id": paymentTypeId])
                         self.saveDataForReuse()
-                        completion?(.success(addCardData.getId()))
+                        var cardInformation = MLCardFormCardInformation(cardId: addCardData.getId(), paymentType: paymentTypeId, bin: bin)
+                        completion?(.success(cardInformation))
                     case .failure(let error):
-                        if case MLCardFormAddCardServiceError.missingPrivateKey = error {
-                            completion?(.success(""))
+                        if case
+                            MLCardFormAddCardServiceError.missingPrivateKey = error {
+                            completion?(.success(MLCardFormCardInformation()))
                         } else {
                             let errorMessage = error.localizedDescription
                             MLCardFormTracker.sharedInstance.trackEvent(path: "/card_form/error", properties: ["error_step": "save_card_data", "error_message": errorMessage])


### PR DESCRIPTION
Para poder continuar con el flujo de checkout luego de enrolar la tarjeta, se necesita información extra al cardId (bin, payment_type_id y fourLastdigits).
Se agrega al protocolo MLCardFormLifeCycleDelegate un método nuevo que devuelva información extra necesaria para el flujo de checkout. Se hace opcional para mantener compatibilidad. Esto lo probé bien con la app de ejemplo y funciona ok. 
Se agrega la clase MLCardFormCardInformation para poder devolver la información necesaria. No se usó struct porque sino no se puede hacer compatible con Objective C