### PR TITLE
Fix - Se agregan a los metodos de MLCardFormCardInformation el @objc

### DIFF
--- a/Source/Model/AddCardData/MLCardFormCardInformation.swift
+++ b/Source/Model/AddCardData/MLCardFormCardInformation.swift
@@ -23,19 +23,19 @@ import Foundation
     
     override init() {}
     
-    public func getCardId() -> String {
+    @objc public func getCardId() -> String {
         return cardId
     }
     
-    public func getBin() -> String {
+    @objc public func getBin() -> String {
         return bin
     }
     
-    public func getPaymentType() -> String {
+    @objc public func getPaymentType() -> String {
         return paymentType
     }
     
-    public func getLastFourDigits() -> String {
+    @objc public func getLastFourDigits() -> String {
         return lastFourDigits
     }
 }


### PR DESCRIPTION
Se agregan a los métodos de MLCardFormCardInformation el @objc para que puedan usarse en objective c. Ya que la clase quedó visible pero los métodos no.