### PR TITLE
BCRA Regulation

### DIFF
--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -24,6 +24,8 @@ open class MLCardFormBuilder: NSObject {
     internal var addStatusBarBackground: Bool?
     internal var animateOnLoad: Bool = false
     internal var shouldConfigureNavigation: Bool?
+    internal let acceptThirdPartyCard: Bool
+    internal let activateCard: Bool
     private var tracker: MLCardFormTracker = MLCardFormTracker.sharedInstance
     
     // MARK: Initialization
@@ -38,6 +40,8 @@ open class MLCardFormBuilder: NSObject {
     public init(publicKey: String,
                 siteId: String,
                 flowId: String,
+                acceptThirdPartyCard: Bool = true,
+                activateCard: Bool = true,
                 lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = publicKey
         self.privateKey = nil
@@ -45,6 +49,8 @@ open class MLCardFormBuilder: NSObject {
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
         self.cardInfoMarketplace = nil
+        self.acceptThirdPartyCard = acceptThirdPartyCard
+        self.activateCard = activateCard
         tracker.set(flowId: flowId, siteId: siteId)
     }
     
@@ -54,6 +60,8 @@ open class MLCardFormBuilder: NSObject {
     ///   - cardInformation: Information related to the card and the transaction you will carry out with it.
     ///   - lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
     public init(publicKey: String,
+                acceptThirdPartyCard: Bool = true,
+                activateCard: Bool = true,
                 cardInformation:MLCardFormCardInformationMarketplace,
                 lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = publicKey
@@ -62,6 +70,8 @@ open class MLCardFormBuilder: NSObject {
         self.flowId = cardInformation.flowId
         self.lifeCycleDelegate = lifeCycleDelegate
         self.cardInfoMarketplace = cardInformation
+        self.acceptThirdPartyCard = acceptThirdPartyCard
+        self.activateCard = activateCard
         tracker.set(flowId: flowId, siteId: siteId)
     }
     
@@ -75,13 +85,17 @@ open class MLCardFormBuilder: NSObject {
     public init(privateKey: String,
                 siteId: String,
                 flowId: String,
+                acceptThirdPartyCard: Bool = true,
+                activateCard: Bool = true,
                 lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = nil
         self.privateKey = privateKey
-        self.siteId = siteId
+        self.siteId = "MLB"
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
         self.cardInfoMarketplace = nil
+        self.acceptThirdPartyCard = acceptThirdPartyCard
+        self.activateCard = activateCard
         tracker.set(flowId: flowId, siteId: siteId)
     }
     
@@ -91,6 +105,8 @@ open class MLCardFormBuilder: NSObject {
     ///   - cardInformation: Information related to the card and the transaction you will carry out with it.
     ///   - lifeCycleDelegate: The protocol to stay informed about credit card creation life cycle. (`didAddCard`)
     public init(privateKey: String,
+                acceptThirdPartyCard: Bool = true,
+                activateCard: Bool = true,
                 cardInformation:MLCardFormCardInformationMarketplace,
                 lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = nil
@@ -99,6 +115,8 @@ open class MLCardFormBuilder: NSObject {
         self.flowId = cardInformation.flowId
         self.lifeCycleDelegate = lifeCycleDelegate
         self.cardInfoMarketplace = cardInformation
+        self.acceptThirdPartyCard = acceptThirdPartyCard
+        self.activateCard = activateCard
         tracker.set(flowId: flowId, siteId: siteId)
     }
     

--- a/Source/Core/Setup/MLCardFormBuilder.swift
+++ b/Source/Core/Setup/MLCardFormBuilder.swift
@@ -90,7 +90,7 @@ open class MLCardFormBuilder: NSObject {
                 lifeCycleDelegate: MLCardFormLifeCycleDelegate) {
         self.publicKey = nil
         self.privateKey = privateKey
-        self.siteId = "MLB"
+        self.siteId = siteId
         self.flowId = flowId
         self.lifeCycleDelegate = lifeCycleDelegate
         self.cardInfoMarketplace = nil

--- a/Source/Model/AddCardData/MLCardFormAddCardBody.swift
+++ b/Source/Model/AddCardData/MLCardFormAddCardBody.swift
@@ -11,4 +11,10 @@ struct MLCardFormAddCardBody: Codable {
     let cardTokenId: String
     let paymentMethod: MLCardFormAddCardPaymentMethod
     let issuer: MLCardFormAddCardIssuer
+    let features: CardFormFeatures
+}
+
+struct CardFormFeatures: Codable {
+    let acceptThirdPartyCard: Bool
+    let activateCard: Bool
 }

--- a/Source/Network/Router/MLCardFormApiRouter.swift
+++ b/Source/Network/Router/MLCardFormApiRouter.swift
@@ -34,18 +34,12 @@ enum MLCardFormApiRouter {
 
     var path: String {
         switch self {
-        case .getCardData:
-            return "/production/px_mobile/v1/card"
-        case .postCardTokenData:
-            return "/v1/card_tokens"
-        case .postCardData:
-            return "/production/px_mobile/v1/card"
-        case .getWebPayInitInscription:
-            return "/production/px_mobile/v1/card_webpay/inscription/init"
-        case .postWebPayFinishInscription:
-            return "/production/px_mobile/v1/card_webpay/inscription/finish"
-        case .getCardDataFromMarketplace:
-            return "/production/px_mobile/v1/card/marketplace"
+        case .getCardData: return "/production/px_mobile/v1/card"
+        case .postCardTokenData: return "/v1/card_tokens"
+        case .postCardData: return "/production/px_mobile/v1/card"
+        case .getWebPayInitInscription: return "/production/px_mobile/v1/card_webpay/inscription/init"
+        case .postWebPayFinishInscription: return "/production/px_mobile/v1/card_webpay/inscription/finish"
+        case .getCardDataFromMarketplace: return "/production/px_mobile/v1/card/marketplace"
         }
     }
 
@@ -103,7 +97,7 @@ enum MLCardFormApiRouter {
         case .getWebPayInitInscription(let queryParams, _),
              .postWebPayFinishInscription(let queryParams, _, _):
             let urlQueryItems = [
-                URLQueryItem(name: MLCardFormAddCardService.QueryKeys.accessToken.getKey, value: queryParams.accessToken),
+                URLQueryItem(name: MLCardFormAddCardService.QueryKeys.accessToken.getKey, value: queryParams.accessToken)
             ]
             return urlQueryItems
         case .getCardDataFromMarketplace(_):

--- a/Source/Network/Router/MLCardFormApiRouter.swift
+++ b/Source/Network/Router/MLCardFormApiRouter.swift
@@ -27,7 +27,7 @@ enum MLCardFormApiRouter {
 
     var host: String {
         switch self {
-        case .getCardData, .postCardTokenData, .postCardData, .getWebPayInitInscription, .postWebPayFinishInscription, .getCardDataFromMarketplace:
+        case .getCardData, .postCardTokenData, .getWebPayInitInscription, .postWebPayFinishInscription, .postCardData, .getCardDataFromMarketplace:
             return "api.mercadopago.com"
         }
     }

--- a/Source/Network/Services/MLCardFormAddCardService.swift
+++ b/Source/Network/Services/MLCardFormAddCardService.swift
@@ -27,13 +27,13 @@ final class MLCardFormAddCardService: MLCardFormAddCardServiceBase {
     }
     
     func saveCard(tokenId: String, addCardData: MLCardFormAddCardService.AddCardBody, completion: ((Result<MLCardFormAddCardData, Error>) -> ())? = nil) {
-        guard let privateKey = privateKey  else {
+        guard let privateKey = privateKey, let acceptThirdPartyCard = acceptThirdPartyCard, let activateCard = activateCard else {
             completion?(.failure(MLCardFormAddCardServiceError.missingPrivateKey))
             return
         }
         let accessTokenParam = MLCardFormAddCardService.AccessTokenParam(accessToken: privateKey)
         let headers = MLCardFormAddCardService.Headers(contentType: "application/json")
-        NetworkLayer.request(router: MLCardFormApiRouter.postCardData(accessTokenParam, headers, buildAddCardBody(tokenId, addCardData: addCardData))) {
+        NetworkLayer.request(router: MLCardFormApiRouter.postCardData(accessTokenParam, headers, buildAddCardBody(tokenId, addCardData: addCardData, features: CardFormFeatures(acceptThirdPartyCard: acceptThirdPartyCard, activateCard: activateCard)))) {
             (result: Result<MLCardFormAddCardData, Error>) in
             completion?(result)
         }
@@ -78,7 +78,7 @@ private extension MLCardFormAddCardService {
         return MLCardFormTokenizationBody(cardNumber: tokenizationData.cardNumber, securityCode: tokenizationData.securityCode, expirationMonth: tokenizationData.expirationMonth, expirationYear: tokenizationData.expirationYear, cardholder: tokenizationData.cardholder, device: tokenizationData.device)
     }
 
-    func buildAddCardBody(_ tokenId: String, addCardData: MLCardFormAddCardService.AddCardBody) -> MLCardFormAddCardBody {
-        return MLCardFormAddCardBody(cardTokenId: tokenId, paymentMethod: addCardData.paymentMethod, issuer: addCardData.issuer)
+    func buildAddCardBody(_ tokenId: String, addCardData: MLCardFormAddCardService.AddCardBody, features: CardFormFeatures) -> MLCardFormAddCardBody {
+        return MLCardFormAddCardBody(cardTokenId: tokenId, paymentMethod: addCardData.paymentMethod, issuer: addCardData.issuer, features: features)
     }
 }

--- a/Source/Network/Services/MLCardFormAddCardService.swift
+++ b/Source/Network/Services/MLCardFormAddCardService.swift
@@ -47,8 +47,7 @@ extension MLCardFormAddCardService {
 
         var getKey: String {
             switch self {
-            case .contentType:
-                return "content-type"
+            case .contentType: return "content-type"
             }
         }
     }

--- a/Source/Network/Services/MLCardFormAddCardServiceBase.swift
+++ b/Source/Network/Services/MLCardFormAddCardServiceBase.swift
@@ -15,11 +15,19 @@ enum MLCardFormAddCardServiceError: Error {
 internal class MLCardFormAddCardServiceBase {
     internal var publicKey: String?
     internal var privateKey: String?
+    internal var acceptThirdPartyCard: Bool?
+    internal var activateCard: Bool?
+
     weak var delegate: MLCardFormInternetConnectionProtocol?
     
-    func update(publicKey: String?, privateKey: String?) {
+    func update(publicKey: String?,
+                privateKey: String?,
+                acceptThirdPartyCard: Bool?,
+                activateCard: Bool?) {
         self.publicKey = publicKey
         self.privateKey = privateKey
+        self.acceptThirdPartyCard = acceptThirdPartyCard
+        self.activateCard = activateCard
     }
 }
 
@@ -28,13 +36,15 @@ extension MLCardFormAddCardServiceBase {
     enum QueryKeys {
         case publicKey
         case accessToken
-
+        case acceptThirdPartyCard
+        case activateCard
+        
         var getKey: String {
             switch self {
-            case .publicKey:
-                return "public_key"
-            case .accessToken:
-                return "access_token"
+            case .publicKey: return "public_key"
+            case .accessToken: return "access_token"
+            case .acceptThirdPartyCard: return "acceptThirdPartyCard"
+            case .activateCard: return "activateCard"
             }
         }
     }

--- a/Source/Network/Services/MLCardFormBinService.swift
+++ b/Source/Network/Services/MLCardFormBinService.swift
@@ -95,16 +95,11 @@ extension MLCardFormBinService {
 
         var getKey: String {
             switch self {
-            case .bin:
-                return "bin"
-            case .siteId:
-                return "site_id"
-            case .platform:
-                return "platform"
-            case .excludedPaymentTypes:
-                return "excluded_payment_types"
-            case .odr:
-                return "odr"
+            case .bin: return "bin"
+            case .siteId: return "site_id"
+            case .platform: return "platform"
+            case .excludedPaymentTypes: return "excluded_payment_types"
+            case .odr: return "odr"
             }
         }
     }

--- a/Source/Network/Services/MLCardFormWebPayService.swift
+++ b/Source/Network/Services/MLCardFormWebPayService.swift
@@ -64,10 +64,8 @@ extension MLCardFormWebPayService {
 
         var getKey: String {
             switch self {
-            case .contentType:
-                return "content-type"
-            case .xpublic:
-                return "X-Public"
+            case .contentType: return "content-type"
+            case .xpublic: return "X-Public"
             }
         }
     }

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -132,7 +132,7 @@ private extension MLCardFormViewController {
                 switch error {
                 case NetworkLayerError.noInternetConnection:
                     title = "Revisa tu conexión a internet.".localized
-                case NetworkLayerError.statusCode(status: let status, message: let message):
+                case NetworkLayerError.statusCode(status: let status, message: let message, userErrorMessage: _):
                     if !String.isNullOrEmpty(message) {
                         title = message
                     }
@@ -195,6 +195,12 @@ private extension MLCardFormViewController {
                         switch error {
                         case NetworkLayerError.noInternetConnection:
                             title = "Revisa tu conexión a internet.".localized
+                            self.andesSnackbar = AndesSnackbar(text: title ?? "", duration: .long, type: .error)
+                            self.andesSnackbar?.show()
+                            self.setFocusOnLastField()
+                            UIAccessibility.post(notification: .announcement, argument: title)
+                        case NetworkLayerError.statusCode(status: let status, message: let message, userErrorMessage: let userErrorMessage) :
+                            title = userErrorMessage ?? "Algo salió mal.".localized
                             self.andesSnackbar = AndesSnackbar(text: title ?? "", duration: .long, type: .error)
                             self.andesSnackbar?.show()
                             self.setFocusOnLastField()

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -355,7 +355,7 @@ extension MLCardFormViewModel {
                 let errorMessage = error.localizedDescription
                 var properties: [String: Any] = ["error_step": "bin_number", "error_message": errorMessage]
                 switch error {
-                case NetworkLayerError.statusCode(status: let status, message: _):
+                case NetworkLayerError.statusCode(status: let status, message: _, userErrorMessage: _):
                     if status == 400 {
                         path = "/card_form/bin_number/unknown"
                         properties = ["bin_number": binNumber.prefix(6)]

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -58,7 +58,7 @@ final class MLCardFormViewModel {
     
     func updateWithBuilder(_ builder: MLCardFormBuilder) {
         self.builder = builder
-        serviceManager.addCardService.update(publicKey: builder.publicKey, privateKey: builder.privateKey)
+        serviceManager.addCardService.update(publicKey: builder.publicKey, privateKey: builder.privateKey, acceptThirdPartyCard: builder.acceptThirdPartyCard, activateCard: builder.activateCard)
         serviceManager.binService.update(siteId: builder.siteId, excludedPaymentTypes: builder.excludedPaymentTypes, flowId: builder.flowId, cardInfoMarketplace: builder.cardInfoMarketplace)
     }
     

--- a/Source/ViewModel/MLCardFormWebPayViewModel.swift
+++ b/Source/ViewModel/MLCardFormWebPayViewModel.swift
@@ -17,8 +17,8 @@ final class MLCardFormWebPayViewModel {
     
     func updateWithBuilder(_ builder: MLCardFormBuilder) {
         self.builder = builder
-        serviceManager.webPayService.update(publicKey: builder.publicKey, privateKey: builder.privateKey)
-        serviceManager.addCardService.update(publicKey: builder.publicKey, privateKey: builder.privateKey)
+        serviceManager.webPayService.update(publicKey: builder.publicKey, privateKey: builder.privateKey, acceptThirdPartyCard: nil, activateCard: nil)
+        serviceManager.addCardService.update(publicKey: builder.publicKey, privateKey: builder.privateKey, acceptThirdPartyCard: builder.acceptThirdPartyCard, activateCard: builder.activateCard)
     }
 
     func getNavigationBarCustomColor() -> (backgroundColor: UIColor?, textColor: UIColor?) {


### PR DESCRIPTION
This PR adds two properties to Card Form `acceptThirdPartyCard` and `activateCard` with a default implementation to true in order to conform with BCRA regulation, sending those properties on `/production/px_mobile/v1/card` post request