### PR TITLE
[PX-2890][fixed] corrige a atualização da máscara corretamente, o que não ocorria na atualização dos campos

### DIFF
--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -447,8 +447,7 @@ extension MLCardFormViewController: MLCardFormFieldNotifierProtocol {
             viewModel.cardDataHandler.securityCode = newValue
 
         case MLCardFormFields.identificationTypesPicker:
-            if let defaultCardDataHandler = viewModel.cardDataHandler as? DefaultCardDataHandler,
-                defaultCardDataHandler.identificationType != newValue {
+            if let defaultCardDataHandler = viewModel.cardDataHandler as? DefaultCardDataHandler {
                 viewModel.updateIDNumberFieldValue(value: newValue)
                 defaultCardDataHandler.identificationType = newValue
                 defaultCardDataHandler.identificationNumber = ""


### PR DESCRIPTION
corrige a atualização da máscara corretamente, o que não ocorria na atualização dos campos quando o usuário entrava com um cartão, depois desistia e tentava entrar com outro. Nesse processo de inserção de um novo cartão (poderia ser na própria tela de inserção de número de cartão) a máscara de DNI posteriormente se perdia, permitindo que o usuário entrasse com o que quisesse.

https://user-images.githubusercontent.com/93728722/150156504-bdc82f33-ee92-4fb5-86b9-95aab70c85f7.mov
