### PR TITLE
(Fixed)[PXN-3097] - Fix bug of selecting the next field when the previous one is invalid

### DIFF
--- a/Source/UI/MLCardFormField/MLCardFormField.swift
+++ b/Source/UI/MLCardFormField/MLCardFormField.swift
@@ -121,6 +121,10 @@ extension MLCardFormField {
             input.keyboardType = keyboardType
         }
     }
+    
+    func setEnableField(_ enabled: Bool) {
+        input.isEnabled = enabled
+    }
 }
 
 // MARK: Private methods.


### PR DESCRIPTION
## What have changed?
Created method to enable/disable MLCardFormField and updated viewModel

## How to test:
Open the sample app, click on add a new card and try to select the name field.