### PR TITLE
(Fixed)[PXN-2908] - Create placeholder for image list

### DIFF
--- a/Source/Core/Extensions/UIImageView+RemoteImage.swift
+++ b/Source/Core/Extensions/UIImageView+RemoteImage.swift
@@ -8,8 +8,12 @@
 import Foundation
 
 extension UIImageView {
-    func setRemoteImage(imageUrl: String, success:((UIImage)->Void)? = nil) {
-        NetworkLayer.request(imageUrl: imageUrl) { [weak self] (image) in
+    func setRemoteImage(
+        imageUrl: URL,
+        success: ((UIImage) -> Void)? = nil,
+        failure: (() -> Void)? = nil
+    ) {
+        NetworkLayer.request(imageUrl: imageUrl, success: { [weak self] (image) in
             guard let self = self else { return }
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
@@ -22,6 +26,7 @@ extension UIImageView {
                         success?(image)
                 })
             }
-        }
+        }, failure: { failure.flatMap { DispatchQueue.main.async(execute: $0) } }
+        )
     }
 }

--- a/Source/Network/NetworkLayer.swift
+++ b/Source/Network/NetworkLayer.swift
@@ -148,8 +148,11 @@ struct NetworkLayer {
         dataTask.resume()
     }
 
-    static func request(imageUrl: String, success: ((UIImage)->Void)?) {
-        guard let url = URL(string: imageUrl) else { return }
+    static func request(
+        imageUrl url: URL,
+        success: ((UIImage) -> Void)?,
+        failure: (() -> Void)? = nil
+    ) {
         let cache = URLCache.shared
         let request = URLRequest(url: url)
         if let data = cache.cachedResponse(for: request)?.data, let image = UIImage(data: data) {
@@ -167,6 +170,8 @@ struct NetworkLayer {
                     print("Retrieve image from Network")
                     #endif
                     success?(image)
+                } else {
+                    failure?()
                 }
             }).resume()
         }

--- a/Source/UI/Controllers/IssuersScreen/MLCardFormIssuerTableViewCell.swift
+++ b/Source/UI/Controllers/IssuersScreen/MLCardFormIssuerTableViewCell.swift
@@ -114,7 +114,7 @@ private extension MLCardFormIssuerTableViewCell {
         contentView.addSubview(titleLabel)
         NSLayoutConstraint.activate([
             titleLabel.widthAnchor.constraint(equalToConstant: contentView.frame.width / deltaWidthRatio),
-            titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: radioButton.centerYAnchor),
             titleLabel.leftAnchor.constraint(equalTo: radioButton.rightAnchor, constant: UI.Margin.M_MARGIN),
             titleLabel.heightAnchor.constraint(equalToConstant: issuerImageHeight)
         ])
@@ -126,7 +126,7 @@ private extension MLCardFormIssuerTableViewCell {
         contentView.addSubview(issuerImageView)
         NSLayoutConstraint.activate([
             issuerImageView.widthAnchor.constraint(equalToConstant: contentView.frame.width / deltaWidthRatio),
-            issuerImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            issuerImageView.centerYAnchor.constraint(equalTo: radioButton.centerYAnchor),
             issuerImageView.leftAnchor.constraint(equalTo: radioButton.rightAnchor, constant: UI.Margin.M_MARGIN),
             issuerImageView.heightAnchor.constraint(equalToConstant: issuerImageHeight)
         ])

--- a/Source/UI/Controllers/IssuersScreen/MLCardFormIssuerTableViewCell.swift
+++ b/Source/UI/Controllers/IssuersScreen/MLCardFormIssuerTableViewCell.swift
@@ -48,27 +48,42 @@ extension MLCardFormIssuerTableViewCell {
         accessibilityLabel = issuer.name
     }
     
+    private func setupImageView(image: UIImage) {
+        issuerImageView.image = image
+        titleLabel.isHidden = true
+        issuerImageView.isHidden = false
+    }
+    
+    private func setupPlaceholder(title: String) {
+        titleLabel.text = title
+        issuerImageView.isHidden = true
+        titleLabel.isHidden = false
+    }
+    
     private func checkHasImage(issuer: MLCardFormIssuer) {
         guard let imageURL = issuer.imageUrl else {
-            titleLabel.text = issuer.name
-            issuerImageView.isHidden = true
-            titleLabel.isHidden = false
+            setupPlaceholder(title: issuer.name)
+            return
+        }
+        
+        guard let url = URL.init(string: imageURL) else {
+            setupPlaceholder(title: issuer.name)
             return
         }
         
         DispatchQueue.global(qos: .background).async {
             do {
-                let data = try Data.init(contentsOf: URL.init(string: imageURL)!)
+                let data = try Data.init(contentsOf: url)
                     DispatchQueue.main.async {
-                        let image: UIImage = UIImage(data: data)!
-                        self.issuerImageView.image = image
-                        self.titleLabel.isHidden = false
+                        if let image = UIImage(data: data) {
+                            self.setupImageView(image: image)
+                        } else {
+                            self.setupPlaceholder(title: issuer.name)
+                        }
                     }
             } catch {
                 DispatchQueue.main.async {
-                    self.titleLabel.text = issuer.name
-                    self.issuerImageView.isHidden = true
-                    self.titleLabel.isHidden = false
+                    self.setupPlaceholder(title: issuer.name)
                 }
             }
         }

--- a/Source/UI/Controllers/IssuersScreen/MLCardFormIssuerTableViewCell.swift
+++ b/Source/UI/Controllers/IssuersScreen/MLCardFormIssuerTableViewCell.swift
@@ -58,7 +58,7 @@ extension MLCardFormIssuerTableViewCell {
         
         DispatchQueue.global(qos: .background).async {
             do {
-                let data = try Data.init(contentsOf: URL.init(string: issuer.name)!)
+                let data = try Data.init(contentsOf: URL.init(string: imageURL)!)
                     DispatchQueue.main.async {
                         let image: UIImage = UIImage(data: data)!
                         self.issuerImageView.image = image

--- a/Source/UI/Controllers/IssuersScreen/MLCardFormIssuerTableViewCell.swift
+++ b/Source/UI/Controllers/IssuersScreen/MLCardFormIssuerTableViewCell.swift
@@ -61,32 +61,18 @@ extension MLCardFormIssuerTableViewCell {
     }
     
     private func checkHasImage(issuer: MLCardFormIssuer) {
-        guard let imageURL = issuer.imageUrl else {
+        guard let imageURL = issuer.imageUrl,
+              let url = URL(string: imageURL)
+        else {
             setupPlaceholder(title: issuer.name)
             return
         }
         
-        guard let url = URL.init(string: imageURL) else {
-            setupPlaceholder(title: issuer.name)
-            return
-        }
-        
-        DispatchQueue.global(qos: .background).async {
-            do {
-                let data = try Data.init(contentsOf: url)
-                    DispatchQueue.main.async {
-                        if let image = UIImage(data: data) {
-                            self.setupImageView(image: image)
-                        } else {
-                            self.setupPlaceholder(title: issuer.name)
-                        }
-                    }
-            } catch {
-                DispatchQueue.main.async {
-                    self.setupPlaceholder(title: issuer.name)
-                }
-            }
-        }
+        issuerImageView.setRemoteImage(
+            imageUrl: url,
+            success: { [weak self] in self?.setupImageView(image: $0) },
+            failure: { [weak self] in self?.setupPlaceholder(title: issuer.name) }
+        )
     }
 }
 


### PR DESCRIPTION
What have changed?
Created the possibility for the screen to add a new credit card to present a Placeholder when there is no image to be shown from the issuer.

How to test:
Use the credentials below to simulate

App: CardForm
siteID: MPE
Cartão: 4280 8202 0290 9119
Nome: Alvaro Noriega
Vencimento: 01/27
DNI: 45.181.595

# unreleased
- default to issuer name if issuer image is not available