### PR TITLE
(Added)[PXN-3064] - Enabler & disabler of Autocompletion Name and ID 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unpublished
+- New backend flag that allows us to enable/disable Name and ID fields autocompletion.
+
 # v0.9.19
 🚀 Release 0.9.19 🚀
 - Refactor MLCardFormCustomMask to fix issues when getting the value unmasked

--- a/Source/Model/BinData/MLCardFormFieldSetting.swift
+++ b/Source/Model/BinData/MLCardFormFieldSetting.swift
@@ -23,19 +23,31 @@ struct MLCardFormFieldSetting: Codable {
 extension MLCardFormFieldSetting {
     static func createSettingForField(_ field: MLCardFormFields, remoteSetting: MLCardFormFieldSetting? = nil, cardUI: MLCardFormCardUI? = nil) -> MLCardFormFieldSetting? {
         switch field {
+            
         case .cardNumber:
             guard let cardUI = cardUI  else { return nil }
             let name: String = field.rawValue
             let type: String = "number"
             let title: String = "Número de tarjeta".localized
             let validationMessage: String = cardUI.extraValidations?.first?.errorMessage ?? "Completa este campo".localized
-            
             let lenght: Int = cardUI.cardNumberLength
             let mask = cardUI.cardPattern.map {
                 String(repeating: "$", count: $0)
                 }.joined(separator: " ")
             
-            return MLCardFormFieldSetting(name: name, lenght: lenght, type: type, title: title, mask: mask, hintMessage: nil, validationPattern: cardUI.validation, validationMessage: validationMessage, extraValidations: cardUI.extraValidations, autocomplete: false)
+            return MLCardFormFieldSetting(
+                name: name,
+                lenght: lenght,
+                type: type,
+                title: title,
+                mask: mask,
+                hintMessage: nil,
+                validationPattern: cardUI.validation,
+                validationMessage: validationMessage,
+                extraValidations: cardUI.extraValidations,
+                autocomplete: false
+            )
+            
         case .securityCode:
             guard let remoteSetting = remoteSetting, let cardUI = cardUI  else { return nil }
             let name: String = remoteSetting.name
@@ -43,13 +55,48 @@ extension MLCardFormFieldSetting {
             let title: String = remoteSetting.title
             let validationMessage: String? = remoteSetting.validationMessage
             let hintMessage: String? = remoteSetting.hintMessage
-            
             let lenght: Int = cardUI.securityCodeLength
             let mask = String(repeating: "$", count: lenght)
             
-            return MLCardFormFieldSetting(name: name, lenght: lenght, type: type, title: title, mask: mask, hintMessage: hintMessage, validationPattern: nil, validationMessage: validationMessage, extraValidations: nil, autocomplete: false)
+            return MLCardFormFieldSetting(
+                name: name,
+                lenght: lenght,
+                type: type,
+                title: title,
+                mask: mask,
+                hintMessage: hintMessage,
+                validationPattern: nil,
+                validationMessage: validationMessage,
+                extraValidations: nil,
+                autocomplete: false
+            )
+            
         default:
             return nil
+        }
+    }
+}
+
+extension Array where Element == MLCardFormFieldSetting {
+    func get(_ cardFormField: MLCardFormFields) -> MLCardFormFieldSetting? {
+        switch cardFormField {
+        case .cardNumber:
+            return self.filter({ $0.name == MLCardFormFields.cardNumber.rawValue}).first
+
+        case .name:
+            return self.filter({ $0.name == MLCardFormFields.name.rawValue}).first
+
+        case .expiration:
+            return self.filter({ $0.name == MLCardFormFields.expiration.rawValue}).first
+
+        case .securityCode:
+            return self.filter({ $0.name == MLCardFormFields.securityCode.rawValue}).first
+
+        case .identificationTypesPicker:
+            return self.filter({ $0.name == MLCardFormFields.identificationTypesPicker.rawValue}).first
+
+        case .identificationTypeNumber:
+            return self.filter({ $0.name == MLCardFormFields.identificationTypeNumber.rawValue}).first
         }
     }
 }

--- a/Source/Model/BinData/MLCardFormFieldSetting.swift
+++ b/Source/Model/BinData/MLCardFormFieldSetting.swift
@@ -79,24 +79,6 @@ extension MLCardFormFieldSetting {
 
 extension Array where Element == MLCardFormFieldSetting {
     func get(_ cardFormField: MLCardFormFields) -> MLCardFormFieldSetting? {
-        switch cardFormField {
-        case .cardNumber:
-            return self.filter({ $0.name == MLCardFormFields.cardNumber.rawValue}).first
-
-        case .name:
-            return self.filter({ $0.name == MLCardFormFields.name.rawValue}).first
-
-        case .expiration:
-            return self.filter({ $0.name == MLCardFormFields.expiration.rawValue}).first
-
-        case .securityCode:
-            return self.filter({ $0.name == MLCardFormFields.securityCode.rawValue}).first
-
-        case .identificationTypesPicker:
-            return self.filter({ $0.name == MLCardFormFields.identificationTypesPicker.rawValue}).first
-
-        case .identificationTypeNumber:
-            return self.filter({ $0.name == MLCardFormFields.identificationTypeNumber.rawValue}).first
-        }
+        filter { $0.name == cardFormField.rawValue }.first
     }
 }

--- a/Source/Model/BinData/MLCardFormFieldSetting.swift
+++ b/Source/Model/BinData/MLCardFormFieldSetting.swift
@@ -17,6 +17,7 @@ struct MLCardFormFieldSetting: Codable {
     let validationPattern: String?
     let validationMessage: String?
     let extraValidations: [MLCardFormExtraValidation]?
+    let autocomplete: Bool?
 }
 
 extension MLCardFormFieldSetting {
@@ -34,7 +35,7 @@ extension MLCardFormFieldSetting {
                 String(repeating: "$", count: $0)
                 }.joined(separator: " ")
             
-            return MLCardFormFieldSetting(name: name, lenght: lenght, type: type, title: title, mask: mask, hintMessage: nil, validationPattern: cardUI.validation, validationMessage: validationMessage, extraValidations: cardUI.extraValidations)
+            return MLCardFormFieldSetting(name: name, lenght: lenght, type: type, title: title, mask: mask, hintMessage: nil, validationPattern: cardUI.validation, validationMessage: validationMessage, extraValidations: cardUI.extraValidations, autocomplete: false)
         case .securityCode:
             guard let remoteSetting = remoteSetting, let cardUI = cardUI  else { return nil }
             let name: String = remoteSetting.name
@@ -46,7 +47,7 @@ extension MLCardFormFieldSetting {
             let lenght: Int = cardUI.securityCodeLength
             let mask = String(repeating: "$", count: lenght)
             
-            return MLCardFormFieldSetting(name: name, lenght: lenght, type: type, title: title, mask: mask, hintMessage: hintMessage, validationPattern: nil, validationMessage: validationMessage, extraValidations: nil)
+            return MLCardFormFieldSetting(name: name, lenght: lenght, type: type, title: title, mask: mask, hintMessage: hintMessage, validationPattern: nil, validationMessage: validationMessage, extraValidations: nil, autocomplete: false)
         default:
             return nil
         }

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -92,23 +92,14 @@ final class MLCardFormViewModel {
         }
         
         if let nameFieldProp = remoteSettings.get(.name) {
-            if nameFieldProp.autocomplete ?? true {
-                let storedNameField = MLCardFormField(
-                    fieldProperty: CardNameFormFieldProperty(
-                        remoteSetting: nameFieldProp,
-                        cardNameValue: storedCardName
-                    )
+            let autocomplete = nameFieldProp.autocomplete ?? true
+            let nameField = MLCardFormField(
+                fieldProperty: CardNameFormFieldProperty(
+                    remoteSetting: nameFieldProp,
+                    cardNameValue: autocomplete ? storedIDNumber : nil
                 )
-                cardFormFields?.append([storedNameField])
-                
-            } else {
-                let defaultNameField = MLCardFormField(
-                    fieldProperty: CardNameFormFieldProperty(
-                        remoteSetting: nameFieldProp
-                    )
-                )
-                cardFormFields?.append([defaultNameField])
-            }
+            )
+            cardFormFields?.append([nameField])
         }
         
         if let expirationFieldSetting = remoteSettings.get(.expiration),

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -82,41 +82,88 @@ final class MLCardFormViewModel {
         guard let cardUI = binData?.cardUI, let remoteSettings = remoteSettings else { return }
         cardFormFields = [[MLCardFormField]]()
         if let cardNumberFieldSettings = MLCardFormFieldSetting.createSettingForField(.cardNumber, cardUI: cardUI) {
-            let numberField = MLCardFormField(fieldProperty: CardNumberFormFieldProperty(remoteSetting: cardNumberFieldSettings, cardNumberValue: tempTextField.getValue()))
+            let numberField = MLCardFormField(
+                fieldProperty: CardNumberFormFieldProperty(
+                    remoteSetting: cardNumberFieldSettings,
+                    cardNumberValue: tempTextField.getValue()
+                )
+            )
             cardFormFields?.append([numberField])
         }
         
-        if let nameFieldProp = remoteSettings.filter({ $0.name == MLCardFormFields.name.rawValue }).first {
+        if let nameFieldProp = remoteSettings.get(.name) {
             if nameFieldProp.autocomplete ?? true {
-                let storedNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp, cardNameValue: storedCardName))
+                let storedNameField = MLCardFormField(
+                    fieldProperty: CardNameFormFieldProperty(
+                        remoteSetting: nameFieldProp,
+                        cardNameValue: storedCardName
+                    )
+                )
                 cardFormFields?.append([storedNameField])
+                
             } else {
-                let defaultNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp))
+                let defaultNameField = MLCardFormField(
+                    fieldProperty: CardNameFormFieldProperty(
+                        remoteSetting: nameFieldProp
+                    )
+                )
                 cardFormFields?.append([defaultNameField])
             }
         }
         
-        if let expirationFieldSetting = remoteSettings.filter({ $0.name == MLCardFormFields.expiration.rawValue}).first,
-           let securityFieldSetting = remoteSettings.filter({ $0.name == MLCardFormFields.securityCode.rawValue}).first,
+        if let expirationFieldSetting = remoteSettings.get(.expiration),
+           let securityFieldSetting = remoteSettings.get(.securityCode),
            let mergedSecurityFieldSetting = MLCardFormFieldSetting.createSettingForField(.securityCode, remoteSetting: securityFieldSetting, cardUI: cardUI) {
             cardFormFields?.append([
-                MLCardFormField(fieldProperty: CardExpirationFormFieldProperty(remoteSetting: expirationFieldSetting)),
-                MLCardFormField(fieldProperty: CardSecurityCodeFormFieldProperty(remoteSetting: mergedSecurityFieldSetting))
+                MLCardFormField(
+                    fieldProperty: CardExpirationFormFieldProperty(
+                        remoteSetting: expirationFieldSetting
+                    )
+                ),
+                MLCardFormField(
+                    fieldProperty: CardSecurityCodeFormFieldProperty(
+                        remoteSetting: mergedSecurityFieldSetting
+                    )
+                )
             ])
         }
         
         if let remoteIdTypes = binData?.identificationTypes, remoteIdTypes.count > 0,
-           let idNumberSetting = remoteSettings.filter({ $0.name == MLCardFormFields.identificationTypeNumber.rawValue}).first {
+           let idNumberSetting = remoteSettings.get(.identificationTypeNumber) {
             if idNumberSetting.autocomplete ?? true {
                 let storedIDFields = [
-                    MLCardFormField(fieldProperty: IDTypeFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, keyboardHeight: measuredKeyboardSize)),
-                    MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, remoteSetting: idNumberSetting, idNumberValue: storedIDNumber))
+                    MLCardFormField(
+                        fieldProperty: IDTypeFormFieldProperty(
+                            identificationTypes: remoteIdTypes,
+                            idTypeValue: storedIDType,
+                            keyboardHeight: measuredKeyboardSize
+                        )
+                    ),
+                    MLCardFormField(
+                        fieldProperty: IDNumberFormFieldProperty(
+                            identificationTypes: remoteIdTypes,
+                            idTypeValue: storedIDType,
+                            remoteSetting: idNumberSetting,
+                            idNumberValue: storedIDNumber
+                        )
+                    )
                 ]
                 cardFormFields?.append(storedIDFields)
+                
             } else {
                 let defaultIDFields = [
-                    MLCardFormField(fieldProperty: IDTypeFormFieldProperty(identificationTypes: remoteIdTypes, keyboardHeight: measuredKeyboardSize)),
-                    MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, remoteSetting: idNumberSetting))
+                    MLCardFormField(
+                        fieldProperty: IDTypeFormFieldProperty(
+                            identificationTypes: remoteIdTypes,
+                            keyboardHeight: measuredKeyboardSize
+                        )
+                    ),
+                    MLCardFormField(
+                        fieldProperty: IDNumberFormFieldProperty(
+                            identificationTypes: remoteIdTypes,
+                            remoteSetting: idNumberSetting
+                        )
+                    )
                 ]
                 cardFormFields?.append(defaultIDFields)
             }
@@ -332,6 +379,7 @@ final class MLCardFormViewModel {
     func shouldReturnIndex(index: Int, isTurnBack: Bool) -> Int {
         return isTurnBack ? index - 1 : index + 1
     }
+
 }
 
 // MARK: IssuersScreen

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -85,7 +85,7 @@ final class MLCardFormViewModel {
             let numberField = MLCardFormField(fieldProperty: CardNumberFormFieldProperty(remoteSetting: cardNumberFieldSettings, cardNumberValue: tempTextField.getValue()))
             cardFormFields?.append([numberField])
         }
-
+        
         if let nameFieldProp = remoteSettings.filter({ $0.name == MLCardFormFields.name.rawValue }).first {
             
             let storedNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp, cardNameValue: storedCardName))
@@ -97,16 +97,16 @@ final class MLCardFormViewModel {
                 cardFormFields?.append([defaultNameField])
             }
         }
-
+        
         if let expirationFieldSetting = remoteSettings.filter({ $0.name == MLCardFormFields.expiration.rawValue}).first,
-            let securityFieldSetting = remoteSettings.filter({ $0.name == MLCardFormFields.securityCode.rawValue}).first,
-            let mergedSecurityFieldSetting = MLCardFormFieldSetting.createSettingForField(.securityCode, remoteSetting: securityFieldSetting, cardUI: cardUI) {
+           let securityFieldSetting = remoteSettings.filter({ $0.name == MLCardFormFields.securityCode.rawValue}).first,
+           let mergedSecurityFieldSetting = MLCardFormFieldSetting.createSettingForField(.securityCode, remoteSetting: securityFieldSetting, cardUI: cardUI) {
             cardFormFields?.append([
                 MLCardFormField(fieldProperty: CardExpirationFormFieldProperty(remoteSetting: expirationFieldSetting)),
                 MLCardFormField(fieldProperty: CardSecurityCodeFormFieldProperty(remoteSetting: mergedSecurityFieldSetting))
-                ])
+            ])
         }
-
+        
         if let remoteIdTypes = binData?.identificationTypes, remoteIdTypes.count > 0,
            let idNumberSetting = remoteSettings.filter({ $0.name == MLCardFormFields.identificationTypeNumber.rawValue}).first {
             
@@ -124,9 +124,8 @@ final class MLCardFormViewModel {
             } else {
                 cardFormFields?.append(defaultIDFields)
             }
-            
-            setupAndRenderCardFormFields(cardFormFields: cardFormFields, notifierProtocol: notifierProtocol)
         }
+        setupAndRenderCardFormFields(cardFormFields: cardFormFields, notifierProtocol: notifierProtocol)
     }
     
     func updateOfflineCardFormFields(notifierProtocol: MLCardFormFieldNotifierProtocol?) {

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -65,7 +65,7 @@ final class MLCardFormViewModel {
     func setupDefaultCardFormFields(notifierProtocol: MLCardFormFieldNotifierProtocol?) {
         cardFormFields = [
             [MLCardFormField(fieldProperty:CardNumberFormFieldProperty())],
-            [MLCardFormField(fieldProperty:CardNameFormFieldProperty(cardNameValue: storedCardName))],
+            [MLCardFormField(fieldProperty:CardNameFormFieldProperty())],
             [MLCardFormField(fieldProperty:CardExpirationFormFieldProperty()),
              MLCardFormField(fieldProperty:CardSecurityCodeFormFieldProperty())],
             [MLCardFormField(fieldProperty:IDTypeFormFieldProperty()),
@@ -87,8 +87,15 @@ final class MLCardFormViewModel {
         }
 
         if let nameFieldProp = remoteSettings.filter({ $0.name == MLCardFormFields.name.rawValue }).first {
-            let nameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp, cardNameValue: storedCardName))
-            cardFormFields?.append([nameField])
+            
+            let storedNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp, cardNameValue: storedCardName))
+            let defaultNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp))
+            
+            if nameFieldProp.autocomplete ?? true {
+                cardFormFields?.append([storedNameField])
+            } else {
+                cardFormFields?.append([defaultNameField])
+            }
         }
 
         if let expirationFieldSetting = remoteSettings.filter({ $0.name == MLCardFormFields.expiration.rawValue}).first,
@@ -101,13 +108,25 @@ final class MLCardFormViewModel {
         }
 
         if let remoteIdTypes = binData?.identificationTypes, remoteIdTypes.count > 0,
-            let idNumberSetting = remoteSettings.filter({ $0.name == MLCardFormFields.identificationTypeNumber.rawValue}).first {
-            cardFormFields?.append([
+           let idNumberSetting = remoteSettings.filter({ $0.name == MLCardFormFields.identificationTypeNumber.rawValue}).first {
+            
+            let storedIDFields = [
                 MLCardFormField(fieldProperty: IDTypeFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, keyboardHeight: measuredKeyboardSize)),
                 MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, remoteSetting: idNumberSetting, idNumberValue: storedIDNumber))
-                ])
+            ]
+            let defaultIDFields = [
+                MLCardFormField(fieldProperty: IDTypeFormFieldProperty(identificationTypes: remoteIdTypes, keyboardHeight: measuredKeyboardSize)),
+                MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, remoteSetting: idNumberSetting))
+            ]
+            
+            if idNumberSetting.autocomplete ?? true {
+                cardFormFields?.append(storedIDFields)
+            } else {
+                cardFormFields?.append(defaultIDFields)
+            }
+            
+            setupAndRenderCardFormFields(cardFormFields: cardFormFields, notifierProtocol: notifierProtocol)
         }
-        setupAndRenderCardFormFields(cardFormFields: cardFormFields, notifierProtocol: notifierProtocol)
     }
     
     func updateOfflineCardFormFields(notifierProtocol: MLCardFormFieldNotifierProtocol?) {

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -87,13 +87,11 @@ final class MLCardFormViewModel {
         }
         
         if let nameFieldProp = remoteSettings.filter({ $0.name == MLCardFormFields.name.rawValue }).first {
-            
-            let storedNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp, cardNameValue: storedCardName))
-            let defaultNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp))
-            
             if nameFieldProp.autocomplete ?? true {
+                let storedNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp, cardNameValue: storedCardName))
                 cardFormFields?.append([storedNameField])
             } else {
+                let defaultNameField = MLCardFormField(fieldProperty: CardNameFormFieldProperty(remoteSetting: nameFieldProp))
                 cardFormFields?.append([defaultNameField])
             }
         }
@@ -109,19 +107,17 @@ final class MLCardFormViewModel {
         
         if let remoteIdTypes = binData?.identificationTypes, remoteIdTypes.count > 0,
            let idNumberSetting = remoteSettings.filter({ $0.name == MLCardFormFields.identificationTypeNumber.rawValue}).first {
-            
-            let storedIDFields = [
-                MLCardFormField(fieldProperty: IDTypeFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, keyboardHeight: measuredKeyboardSize)),
-                MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, remoteSetting: idNumberSetting, idNumberValue: storedIDNumber))
-            ]
-            let defaultIDFields = [
-                MLCardFormField(fieldProperty: IDTypeFormFieldProperty(identificationTypes: remoteIdTypes, keyboardHeight: measuredKeyboardSize)),
-                MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, remoteSetting: idNumberSetting))
-            ]
-            
             if idNumberSetting.autocomplete ?? true {
+                let storedIDFields = [
+                    MLCardFormField(fieldProperty: IDTypeFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, keyboardHeight: measuredKeyboardSize)),
+                    MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, idTypeValue: storedIDType, remoteSetting: idNumberSetting, idNumberValue: storedIDNumber))
+                ]
                 cardFormFields?.append(storedIDFields)
             } else {
+                let defaultIDFields = [
+                    MLCardFormField(fieldProperty: IDTypeFormFieldProperty(identificationTypes: remoteIdTypes, keyboardHeight: measuredKeyboardSize)),
+                    MLCardFormField(fieldProperty: IDNumberFormFieldProperty(identificationTypes: remoteIdTypes, remoteSetting: idNumberSetting))
+                ]
                 cardFormFields?.append(defaultIDFields)
             }
         }


### PR DESCRIPTION
## What has changed?

To comply with 3rd party Cards regulation in MLA (and as a new feature) we will add a new flag that allows us to enable/disable **Name and ID fields autocompletion**. 

We moved this to backend, so if we need it in future for other sites (or re-enabling it in MLA) we can do it without waiting for mobile releases.

In FieldSettings model, if autocomplete flag is true or nil, name/ID will autocomplete. If it is false, name/ID will not autocomplete even if it stored a previously used name/ID. 

| Before: All | After: No Autocomplete MLA | After: Autocomplete MLB
|:-:|:-:|:-:|
|  ![AutocompleteBeforeMLAiOS15](https://user-images.githubusercontent.com/61248081/152067419-0e0d88a0-fd41-4d4a-8704-64dac50f9f0f.gif)| ![AutocompleteAfterMLAiOS13](https://user-images.githubusercontent.com/61248081/152068128-4b3e22b7-d663-49b1-9746-a21fa6b065ca.gif)| ![AutocompleteAfterMLBiOS13](https://user-images.githubusercontent.com/61248081/152068019-d63e0aba-f0db-494e-8b42-55cebfe9f874.gif)

## How to test:

Backend new _autocomplete_ field is currently in Alpha, and was tested compiling the wallet with these changes. It can also be tested with this [mock](https://run.mocky.io/v3/76b0ada6-f8a2-414e-a795-b2568bd2f198).
 