### PR TITLE
(Fixed)[PXN-3047] - Adjusted card number field mask according to pasted text if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unpublished
+- Adjusted card number field mask according to pasted text if needed
+
 # v0.9.23
 🚀 Release 0.9.23 🚀
 - Fixed parameters in trackEvent.

--- a/Source/UI/Controllers/MLCardFormViewController.swift
+++ b/Source/UI/Controllers/MLCardFormViewController.swift
@@ -541,6 +541,19 @@ extension MLCardFormViewController: MLCardFormFieldNotifierProtocol {
     public func invalidInput(from: MLCardFormField) {
         trackInvalidEvent(from)
     }
+    
+    public func pastedText(_ text: String?, from: MLCardFormField) {
+        viewModel.validatePastedTextIfNeeded(text: text, cardFormField: from, notifierProtocol: self) { [weak self] in
+            guard let self = self else { return }
+            self.viewModel.tempTextField.doFocus()
+            self.cardFieldCollectionView?.reloadData()
+            self.cardFieldCollectionView?.layoutIfNeeded()
+            if let field = self.viewModel.cardFormFields?.first?.first {
+                field.doFocus()
+                UIAccessibility.post(notification: .announcement, argument: field.input.text)
+            }
+        }
+    }
 }
 
 // MARK: IssuerSelectedProtocol

--- a/Source/UI/CustomTextField/PastedTextField.swift
+++ b/Source/UI/CustomTextField/PastedTextField.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+protocol PastedTextFieldDelegate: AnyObject {
+    func pastedText(_ text: String?)
+}
+
+extension PastedTextFieldDelegate {
+    func pastedText(_ text: String?) {
+        //this is a empty implementation to allow this method to be optional
+    }
+}
+
+final class PastedTextField: UITextField {
+    weak var pastedTextFieldDelegate: PastedTextFieldDelegate? = nil
+    
+    override func paste(_ sender: Any?) {
+        pastedTextFieldDelegate?.pastedText(UIPasteboard.general.string)
+        super.paste(sender)
+    }
+}

--- a/Source/UI/MLCardFormField/MLCardFormField.swift
+++ b/Source/UI/MLCardFormField/MLCardFormField.swift
@@ -27,7 +27,7 @@ final public class MLCardFormField: UIView {
     internal var measuredKeyboardSize: CGRect = CGRect.zero
 
     // MARK: Internals UI
-    internal let input = UITextField()
+    internal let input = PastedTextField()
     internal let helpLabel = UILabel()
     internal let titleLabel = UILabel()
     internal let bottomLine = UIView.createView()
@@ -200,6 +200,10 @@ private extension MLCardFormField {
                 input.rightViewMode = .always
             }
         }
+        
+        if let cardFormField = MLCardFormFields(rawValue: property.fieldId()), cardFormField == .cardNumber {
+            input.pastedTextFieldDelegate = self
+        }
     }
 
     func setupBottomLine() {
@@ -301,5 +305,11 @@ internal extension MLCardFormField {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             UIAccessibility.post(notification: .announcement, argument: text)
         }
+    }
+}
+
+extension MLCardFormField: PastedTextFieldDelegate {
+    func pastedText(_ text: String?) {
+        notifierProtocol?.pastedText(text, from: self)
     }
 }

--- a/Source/UI/MLCardFormField/Protocols/MLCardFormFieldNotifierProtocol.swift
+++ b/Source/UI/MLCardFormField/Protocols/MLCardFormFieldNotifierProtocol.swift
@@ -15,6 +15,7 @@ public protocol MLCardFormFieldNotifierProtocol: NSObjectProtocol {
     func didEndEditing(from: MLCardFormField)
     func didTapClear(from: MLCardFormField)
     func invalidInput(from: MLCardFormField)
+    func pastedText(_ text: String?, from: MLCardFormField)
 }
 
 extension MLCardFormFieldNotifierProtocol {
@@ -39,6 +40,10 @@ extension MLCardFormFieldNotifierProtocol {
     }
     
     public func didEndEditing(from: MLCardFormField){
+        //this is a empty implementation to allow this method to be optional
+    }
+    
+    public func pastedText(_ text: String?, from: MLCardFormField) {
         //this is a empty implementation to allow this method to be optional
     }
 }


### PR DESCRIPTION
## What have changed?
When the user tries to paste a credit card number greater than 16 digits, the number field does not accept the missing digits.

I made an implementation that changes the mask format according to the pasted string.

## How to test:
- Trying to paste a card number with 16 digits or more.

## Prints for layout changes:
-

## Extras:
https://mercadolibre.atlassian.net/browse/PXN-3047