### PR TITLE
[PXN-3468] Fixing exception in Replace Characters In Range Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+# v0.9.26 [Unreleased]
+🚀 Release 0.9.26 🚀
+- Fixing exception in Replace Characters In Range Function
+
 # v0.9.25
+🚀 Release 0.9.25 🚀
 - Adjusted card number field mask according to pasted text if needed
 
 # v0.9.23

--- a/MLCardForm.podspec
+++ b/MLCardForm.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLCardForm"
-  s.version          = "0.9.25"
+  s.version          = "0.9.26"
   s.summary          = "MLCardForm for iOS"
   s.homepage         = "https://www.mercadolibre.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/Source/UI/MLCardFormField/Mask/MLCardFormCustomMask.swift
+++ b/Source/UI/MLCardFormField/Mask/MLCardFormCustomMask.swift
@@ -69,6 +69,9 @@ final class MLCardFormCustomMask {
         _ range: NSRange,
         with string: String
     ) -> String {
+        guard Range.init(range, in: self.value) != nil else {
+            return self.value
+        }
         let newString = (self.value as NSString).replacingCharacters(in: range, with: string)
         return applyMask(to: newString)
     }

--- a/Tests/MLCardFormCustomMaskTests.swift
+++ b/Tests/MLCardFormCustomMaskTests.swift
@@ -38,6 +38,18 @@ final class MLCardFormCustomMaskTests: XCTestCase {
         XCTAssertEqual(sut.unmaskedText, "12345678")
     }
     
+    func testInvalidRange() {
+        let value = "12 345 678"
+        let sut = MLCardFormCustomMask(mask: "$$.$$$.$$$")
+        
+        XCTAssertEqual(sut.applyMask(to: value), "12.345.678")
+
+        sut.shouldChangeCharactersIn(.init(location: 10, length: 1), with: "")
+        
+        XCTAssertEqual(sut.value, "12.345.678")
+        XCTAssertEqual(sut.unmaskedText, "12345678")
+    }
+    
     func testBackSpaceWithMask() {
         let value = "12 345 678"
         let sut = MLCardFormCustomMask(mask: "$$.$$$.$$$")


### PR DESCRIPTION
Fixing the following exception:
```
NSInvalidArgumentException in buyingflow-mobile-ios
-[__NSCFString replaceCharactersInRange:withString:]: Range or index out of bounds
```
By checking if the given range is valid in the given string.