### PR TITLE
(FIXED)[PXN-3693] Fixing unable to progress adding card with name with last char is whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Fixing unable to progress adding card with name when last char is whitespace
+
 # v0.9.26
 🚀 Release 0.9.26 🚀
 - Fixing exception in Replace Characters In Range Function

--- a/Source/UI/MLCardFormField/MLCardFormField.swift
+++ b/Source/UI/MLCardFormField/MLCardFormField.swift
@@ -278,7 +278,7 @@ internal extension MLCardFormField {
 
     func isValid() -> Bool {
         guard let value = getValue() else { return false }
-        if property.isValid(value: value) {
+        if property.isValid(value: value.trimmingCharacters(in: .whitespaces)) {
             showHelpLabel()
             bottomLine.backgroundColor = highlightColor
             UINotificationFeedbackGenerator().notificationOccurred(.success)


### PR DESCRIPTION
Fixing unable to progress adding card with name with last char is whitespace

![image](https://user-images.githubusercontent.com/94566493/164770559-98e372b5-5d03-40a6-a179-ed5fa999d842.png)

how test
- just try adding a card using a name with " " as last char in name field