### PR TITLE
Cardform Configurator: Refactor and Migration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/mercadolibre/fury_websec-git-hooks
+    rev: v1.0.5
+    hooks:
+      - id: pre_commit_hook
+        stages: [commit]
+      - id: post_commit_hook
+        stages: [post-commit]
+
+  # Next hooks are Code Quality hooks. 
+  # If you want them to run on each commit, uncomment them
+  # These are OPTIONAL.
+  
+  # - repo: https://github.com/mercadolibre/fury_code-quality-pre-commit-ios
+  #   rev: 1.0.0
+  #   hooks:
+  #   - id: uncrustify
+  #     args:
+  #       - -l
+  #       - OC
+  #       - -c
+  #       - ./.code_quality/uncrustify.cfg
+  #       - --no-backup
+  #       - --replace
+  # - repo: https://github.com/realm/SwiftLint
+  #   rev: 0.45.1
+  #   hooks:
+  #   - id: swiftlint
+  #     args:
+  #       - --config
+  #       - ./.code_quality/.swiftlint.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 ## [Unreleased]
 
-## [v0.14.0] - 2022-10-25
+## [v0.15.0] - 2022-10-25
 ### Migrated
 - According changes on CardForm configuration provider
+
+# v0.14.1
+🚀 Release 0.14.1 🚀
+- Added default method to get Platform field for postCardData requisition
+
+# v0.14.0
+🚀 Release 0.14.0 🚀
+- Two optional fieds added to the header of the postCardData requisition
 
 # v0.13.0
 🚀 Release 0.13.0 🚀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+## [v0.14.0] - 2022-10-25
+### Migrated
+- According changes on CardForm configuration provider
+
 # v0.13.0
 🚀 Release 0.13.0 🚀
 - Fix mask issue

--- a/Example/Example_CardForm/ViewController.swift
+++ b/Example/Example_CardForm/ViewController.swift
@@ -70,10 +70,10 @@ extension ViewController: MLCardFormTrackerDelegate {
     }
 }
 
-// ESC
+// MARK: CardForm
 extension ViewController: MLCardFormESCProtocol {
-    func saveESC(config: MLCardFormESCConfig, firstSixDigits: String, lastFourDigits: String, esc: String) -> Bool {
-        return false
+    func saveESC(using config: MLCardFormESCConfig, with cardInfo: CardInfo) -> Bool {
+        false
     }
 }
 
@@ -87,7 +87,7 @@ private extension ViewController {
         builder.setLanguage("es")
         builder.setExcludedPaymentTypes(["ticket"])
 
-        MLCardFormConfiguratorManager.with(esc: self, tracking: self)
+        MLCardFormConfiguratorManager.initialize()
         
         let cardFormVC = MLCardForm(builder: builder).setupController()
         navigationController?.pushViewController(cardFormVC, animated: true)
@@ -100,7 +100,7 @@ private extension ViewController {
         let builder = MLCardFormBuilder(privateKey: privateKey, siteId: "MLC", flowId: "MLCardForm-TestApp", lifeCycleDelegate: self)
         builder.setLanguage("es")
 
-        MLCardFormConfiguratorManager.with(esc: self, tracking: self)
+        MLCardFormConfiguratorManager.initialize()
         
         let cardFormVC = MLCardForm(builder: builder).setupWebPayController()
         navigationController?.pushViewController(cardFormVC, animated: true)

--- a/MLCardForm.podspec
+++ b/MLCardForm.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLCardForm"
-  s.version          = "0.14.0"
+  s.version          = "0.15.0"
   s.summary          = "MLCardForm for iOS"
   s.homepage         = "https://www.mercadolibre.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/MLCardForm.podspec
+++ b/MLCardForm.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLCardForm"
-  s.version          = "0.13.0"
+  s.version          = "0.14.0"
   s.summary          = "MLCardForm for iOS"
   s.homepage         = "https://www.mercadolibre.com"
   s.license          = { :type => "MIT", :file => "LICENSE" }
@@ -20,6 +20,9 @@ Pod::Spec.new do |s|
     s.dependency 'MLUI', '~> 5.0'
     s.dependency 'AndesUI', '~> 3.0'
     s.dependency 'MLCardDrawer', '~> 1.0'
+    s.dependency 'MLESCManager', '~> 2.0'
+    s.dependency 'MLMelidata', '~> 0.13'
+    s.dependency 'MLAnalytics', '~> 2.18'
   end
 
   s.test_spec 'Tests' do |test_spec|

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,5 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
+source 'git@github.com:mercadolibre/mobile-ios_specs.git'
 
 workspace 'CardForm'
 project 'Example/Example_CardForm.xcodeproj'

--- a/Source/Core/Tracking/MLCardFormTrackerDelegate.swift
+++ b/Source/Core/Tracking/MLCardFormTrackerDelegate.swift
@@ -3,14 +3,10 @@
 //  MLCardForm
 //
 //  Created by Eric Ertl on 26/11/2019.
-//
+//  Refactor by bgarelli, 10/25/2022
 
-import Foundation
-
-/**
- Protocol to stay notified about our tracking screens/events.
- */
-@objc public protocol MLCardFormTrackerDelegate: NSObjectProtocol {
+/// Protocol to stay notified about our tracking screens/events.
+public protocol MLCardFormTrackerDelegate {
     /**
      This method is called when a new screen is shown to the user and tracked by our Checkout.
      - parameter screenName: Screenname Melidata catalog.
@@ -19,7 +15,7 @@ import Foundation
     func trackScreen(screenName: String, extraParams: [String: Any]?)
     
     /**
-     This method is called when a new event is ocurred to the user and tracked by our Checkout.
+     This method is called when a new event is occurred to the user and tracked by our Checkout.
      - parameter screenName: Event name.
      - parameter extraParams: Extra data.
      */

--- a/Source/Managers/ESC/MLCardFormESCDefault.swift
+++ b/Source/Managers/ESC/MLCardFormESCDefault.swift
@@ -3,15 +3,19 @@
 //  MLCardForm
 //
 //  Created by Eric Ertl on 06/12/2019.
-//
+//  Refactor by bgarelli, 10/25/2022
 
-import Foundation
+import MLESCManager
 
-/**
- Default PX implementation of ESC for public distribution.
- */
-final class MLCardFormESCDefault: NSObject, MLCardFormESCProtocol {
-    func saveESC(config: MLCardFormESCConfig, firstSixDigits: String, lastFourDigits: String, esc: String) -> Bool {
-        return false
+/// Default PX implementation of ESC for public distribution.
+struct MLCardFormESCDefault: MLCardFormESCProtocol {
+    func saveESC(using config: MLCardFormESCConfig, with cardInfo: CardInfo) -> Bool {
+        guard config.enabled else {
+            return false
+        }
+        let escManager = MLESCManager(sessionId: config.getSessionId())
+        escManager.setFlow(flow: config.getFlowId())
+        let (esc, firstFour, lastSix) = cardInfo
+        return escManager.saveESC(esc: esc, firstSixDigits: firstFour, lastFourDigits: lastSix)
     }
 }

--- a/Source/Managers/ESC/MLCardFormESCProtocol.swift
+++ b/Source/Managers/ESC/MLCardFormESCProtocol.swift
@@ -3,14 +3,11 @@
 //  MLCardForm
 //
 //  Created by Eric Ertl on 06/12/2019.
-//
+//  Refactor by bgarelli, 10/25/2022
 
-import Foundation
+public typealias CardInfo = (firstSixDigits: String, lastFourDigits: String, esc: String)
 
-/**
- Use this protocol to implement ESC functionality
- */
-/** :nodoc: */
-@objc public protocol MLCardFormESCProtocol: NSObjectProtocol {
-    @discardableResult func saveESC(config: MLCardFormESCConfig, firstSixDigits: String, lastFourDigits: String, esc: String) -> Bool
+/// ESC functionality contract
+public protocol MLCardFormESCProtocol {
+    @discardableResult func saveESC(using config: MLCardFormESCConfig, with cardInfo: CardInfo) -> Bool
 }

--- a/Source/Managers/MLCardFormConfiguratorManager.swift
+++ b/Source/Managers/MLCardFormConfiguratorManager.swift
@@ -3,26 +3,73 @@
 //  MLCardForm
 //
 //  Created by Eric Ertl on 06/12/2019.
-//
+//  Refactor by bgarelli, 10/25/2022
 
-import Foundation
+import MLMelidata
+import MLAnalytics
 
-/** :nodoc: */
-@objcMembers
-open class MLCardFormConfiguratorManager: NSObject {
-    // MARK: Internal definitions.
-    internal static var escProtocol: MLCardFormESCProtocol = MLCardFormESCDefault()
-    internal static var escConfig: MLCardFormESCConfig = MLCardFormESCConfig.createConfig()
+public final class MLCardFormConfiguratorManager {
+    public var builder: MLMelidataTrackBuilder?
+    public var session: MLSession?
 
-    // MARK: Public
-    // Set external implementation of MLCardFormESCProtocol
-    public static func with(esc escProtocol: MLCardFormESCProtocol, tracking trackingProtocol: MLCardFormTrackerDelegate) {
-        self.escProtocol = escProtocol
-        MLCardFormTracker.sharedInstance.setTrackerDelegate(trackingProtocol)
+    static var escProtocol: MLCardFormESCProtocol = MLCardFormESCDefault()
+    static var escConfig: MLCardFormESCConfig = MLCardFormESCConfig.createConfig()
+    private static var shared = MLCardFormConfiguratorManager()
+
+    public static func initialize() {
+        MLCardFormTracker.sharedInstance.setTrackerDelegate(shared)
     }
     
     static func updateConfig(escEnabled: Bool = false) {
         let escConfig = MLCardFormESCConfig.createConfig(enabled: escEnabled)
         self.escConfig = escConfig
+    }
+}
+
+extension MLCardFormConfiguratorManager: MLCardFormTrackerDelegate {
+    public func trackScreen(screenName: String, extraParams: [String : Any]?) {
+        self.builder = MLMelidata.trackView(withPath: screenName)
+        self.builder?.withDictionary(extraParams)
+        self.builder?.send()
+
+        if MLAuthenticationManager.sharedInstance()?.getSession() != nil {
+            self.session = MLAuthenticationManager.sharedInstance()?.getSession()
+        }
+
+        if let flowId = extraParams?["flow_id"] {
+            MLGAI.sharedInstance()?
+                .trackScreen(
+                    withPath: screenName.uppercased(),
+                    key: self.session?.siteId,
+                    userId: self.session?.userId,
+                    sampleRate: nil,
+                    customDimensions: ["7": "MARKETPLACE", "8": "CORE", "89": flowId]
+                )
+        }
+    }
+
+    public func trackEvent(screenName: String?, extraParams: [String : Any]?) {
+        self.builder = MLMelidata.trackEvent(withPath: screenName)
+        self.builder?.withDictionary(extraParams)
+        self.builder?.send()
+
+        guard let screenName = screenName, screenName.contains("invalid"),
+              let flowId = extraParams?["flow_id"]
+        else { return }
+
+        var action = "INVALID"
+        if screenName.contains("date") {
+            action = "DATE_" + action
+        } else if screenName.contains("cvv") {
+            action = "CVV_" + action
+        }
+
+        MLGAI.sharedInstance()?.trackEvent(
+            withAction: action,
+            category: "/CARD_FORM/",
+            label: nil,
+            value: nil,
+            customDimensions: ["7": "MARKETPLACE", "8": "CORE", "89": flowId]
+        )
     }
 }

--- a/Source/ViewModel/MLCardFormViewModel.swift
+++ b/Source/ViewModel/MLCardFormViewModel.swift
@@ -3,7 +3,7 @@
 //  MLCardForm
 //
 //  Created by Esteban Adrian Boffa on 31/10/2019.
-//
+//  Refactor by bgarelli, 10/25/2022
 
 import Foundation
 import MLCardDrawer
@@ -528,7 +528,7 @@ extension MLCardFormViewModel {
                 if let esc = tokenCardData.esc,
                    let firstSixDigits = tokenCardData.firstSixDigits,
                    let lastFourDigits = tokenCardData.lastFourDigits {
-                    MLCardFormConfiguratorManager.escProtocol.saveESC(config: MLCardFormConfiguratorManager.escConfig, firstSixDigits: firstSixDigits, lastFourDigits: lastFourDigits, esc: esc)
+                    MLCardFormConfiguratorManager.escProtocol.saveESC(using: MLCardFormConfiguratorManager.escConfig, with: (esc, firstSixDigits, lastFourDigits))
                 }
                 self.serviceManager.addCardService.saveCard(tokenId: tokenCardData.id, addCardData: addCardData, completion: { [weak self] (result: Result<MLCardFormAddCardData, Error>) in
                     guard let self = self else { return }
@@ -545,7 +545,7 @@ extension MLCardFormViewModel {
                                                                                  MLCardFormTracker.TrackerParams.paymentMethodType.value: paymentTypeId])
                         self.saveDataForReuse()
                         let lastFourDigits = tokenCardData.lastFourDigits ?? ""
-                        var cardInformation = MLCardFormCardInformation(cardId: addCardData.getId(), paymentType: paymentTypeId, bin: bin, lastFourDigits: lastFourDigits)
+                        let cardInformation = MLCardFormCardInformation(cardId: addCardData.getId(), paymentType: paymentTypeId, bin: bin, lastFourDigits: lastFourDigits)
                         completion?(.success(cardInformation))
                     case .failure(let error):
                         if case


### PR DESCRIPTION
* Refactor
- MLCardFormESCProtocol: optimizes `saveESC` firm to receive a tuple instead of 3 parameters.
- MLCardFormConfiguratorManager: `initialize` instead of previous `withESC` was passing internal arguments from outside.
- Removes unnecessary exposure to objC of types and methods.
* Migration
- Moves tracking delegate from configurator to MLCardFormConfiguratorManager